### PR TITLE
Complete TransactionCategory CRUD

### DIFF
--- a/church-finance-backend/Dockerfile
+++ b/church-finance-backend/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1.7
+
+# --- Build stage -------------------------------------------------------------
+FROM gradle:9.0.0-jdk21-alpine AS build
+WORKDIR /workspace
+
+# Cache dependencies first for faster incremental builds.
+COPY settings.gradle.kts build.gradle.kts gradle.properties* ./
+COPY gradle ./gradle
+RUN gradle --no-daemon dependencies > /dev/null 2>&1 || true
+
+COPY src ./src
+RUN gradle --no-daemon clean bootJar -x test
+
+# --- Runtime stage -----------------------------------------------------------
+FROM eclipse-temurin:21-jre-alpine AS runtime
+WORKDIR /app
+
+RUN addgroup -S app && adduser -S app -G app
+USER app
+
+COPY --from=build /workspace/build/libs/*.jar /app/app.jar
+
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "/app/app.jar"]

--- a/church-finance-backend/docker-compose.yml
+++ b/church-finance-backend/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  postgres:
+    image: postgres:18-alpine
+    container_name: church-finance-db
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-app}
+      POSTGRES_USER: ${POSTGRES_USER:-church_finance}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-church_finance}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - church-finance-pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-church_finance} -d ${POSTGRES_DB:-app}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    build:
+      context: .
+    container_name: church-finance-app
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      SPRING_PROFILES_ACTIVE: ${SPRING_PROFILES_ACTIVE:-docker}
+      DATABASE_URL: ${DATABASE_URL:-jdbc:postgresql://postgres:5432/${POSTGRES_DB:-app}}
+      DATABASE_USERNAME: ${DATABASE_USERNAME:-${POSTGRES_USER:-church_finance}}
+      DATABASE_PASSWORD: ${DATABASE_PASSWORD:-${POSTGRES_PASSWORD:-church_finance}}
+    ports:
+      - "${APP_PORT:-8080}:8080"
+
+volumes:
+  church-finance-pgdata:

--- a/church-finance-backend/src/documents/api-integration-spec.md
+++ b/church-finance-backend/src/documents/api-integration-spec.md
@@ -1,0 +1,137 @@
+# Church Finance — API Integration Specification
+
+This document is the canonical reference for clients integrating with the Church
+Finance HTTP API. It describes conventions that apply across all endpoints; the
+machine-readable contract for individual operations lives in the OpenAPI
+specification served at runtime.
+
+## 1. Discovery
+
+| Resource         | URL                  |
+| ---------------- | -------------------- |
+| OpenAPI document | `/v3/api-docs`       |
+| Swagger UI       | `/swagger-ui.html`   |
+
+The OpenAPI document is generated from the Spring controllers and is the source
+of truth for request/response schemas, status codes, and validation rules. This
+markdown document is intentionally narrative and explains conventions, not
+individual endpoints.
+
+## 2. Versioning
+
+All endpoints are namespaced under `/api/v{n}` (currently `/api/v1`). Breaking
+changes require a new major version path. Backwards-compatible additions
+(new endpoints, new optional fields) may be made within an existing version.
+
+## 3. Grouping & Tagging Convention
+
+The API is organised in two layers:
+
+1. **Groups (per aggregate)** — top-level switcher in Swagger UI. Each DDD
+   aggregate that exposes endpoints is registered as a `GroupedOpenApi` bean
+   in `shared/api/OpenApiConfig.kt`. Selecting a group in the Swagger UI
+   "Select a definition" dropdown narrows the view to that aggregate, and the
+   group is also available as a standalone OpenAPI document at
+   `/v3/api-docs/<group>` for client codegen.
+2. **Tags (per resource within an aggregate)** — flat resource names like
+   `Churches`, `Transaction Categories`. Because the group already conveys the
+   aggregate, tags do not repeat the aggregate name as a prefix.
+
+A special `all` group exposes every operation across every aggregate and is
+useful for browsing the full surface area in one place.
+
+Current groups:
+
+| Group            | Aggregate          | Tags inside the group                |
+| ---------------- | ------------------ | ------------------------------------ |
+| `all`            | (everything)       | (all tags)                           |
+| `administration` | `administration`   | `Churches`, `Transaction Categories` |
+
+When a new aggregate exposes its first endpoint:
+
+1. Add a `GroupedOpenApi` bean for it in `OpenApiConfig.kt` (one line, matched
+   by package pattern).
+2. Tag controllers within that aggregate with flat resource names — do not
+   include the aggregate name in the tag.
+3. Update the table above.
+
+## 4. Identifiers
+
+- All public identifiers in API payloads are `UUID` (string, RFC 4122 form).
+- Internally the domain uses ULIDs; the persistence and API boundaries convert
+  between ULID and UUID. Clients should treat ids as opaque strings.
+
+## 5. Multi-Tenancy
+
+Most resources are scoped to a church. Where a resource lives under a parent
+church, the church id appears in the URL path. The `User` aggregate is the
+only resource that is not church-scoped.
+
+## 6. Optimistic Locking
+
+Mutable aggregates expose a `version: long` field on every read response.
+Update and state-transition endpoints require this version, either:
+
+- as a field in the request body (PUT updates), or
+- as a `version` query parameter (PATCH state transitions such as
+  activate/deactivate).
+
+If the supplied version does not match the current persisted version, the
+server responds with `409 Conflict`. Clients should re-read the resource and
+retry.
+
+## 7. HTTP Conventions
+
+| Method   | Usage                                                              |
+| -------- | ------------------------------------------------------------------ |
+| `GET`    | Retrieve a resource. Safe and idempotent.                          |
+| `POST`   | Create a new resource. Returns `201 Created` with the new entity.  |
+| `PUT`    | Full replacement of mutable fields. Idempotent.                    |
+| `PATCH`  | State transitions and partial updates (e.g. activate/deactivate).  |
+| `DELETE` | Reserved — most domain resources are deactivated, not deleted.     |
+
+### Status codes
+
+| Code  | Meaning                                                      |
+| ----- | ------------------------------------------------------------ |
+| `200` | Successful read/update                                       |
+| `201` | Successful create                                            |
+| `400` | Request body or parameters failed validation                 |
+| `404` | Resource not found                                           |
+| `409` | Optimistic locking conflict or domain invariant violation    |
+| `500` | Unhandled server error                                       |
+
+## 8. Validation
+
+Request bodies are validated with Jakarta Bean Validation. Strings declared as
+required must be non-blank (`@NotBlank`) — empty strings and whitespace-only
+strings are rejected. Validation failures produce `400 Bad Request`.
+
+## 9. Money & Numeric Types
+
+All monetary amounts are serialised as JSON numbers backed by `BigDecimal` on
+the server. Clients **must** preserve precision (do not round-trip through
+floating point) and **must** compare amounts using a decimal-aware comparison.
+
+## 10. Authentication
+
+To be defined. The API will adopt a bearer-token scheme; this section will be
+expanded once the auth aggregate is wired into the controllers.
+
+## 11. Adding New Endpoints
+
+When introducing a new controller:
+
+1. Place it under `<aggregate>/api/` following the layered structure.
+2. If this is the first endpoint in the aggregate, add a `GroupedOpenApi`
+   bean for it in `shared/api/OpenApiConfig.kt`.
+3. Annotate the class with `@Tag(name = "<Resource>", description = "…")` —
+   flat resource name, no aggregate prefix.
+4. Annotate each handler with `@Operation(summary, description)` and an
+   `@ApiResponses` block enumerating the expected status codes.
+5. Annotate path/query parameters with `@Parameter` so the generated docs are
+   self-explanatory.
+6. If the operation participates in optimistic locking, document the
+   `version` requirement in the operation description.
+7. Update this specification if a new convention is introduced or a new
+   group/tag is added to the table in §3.

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/ChurchController.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/ChurchController.kt
@@ -1,6 +1,11 @@
 package com.calvintech.churchfinance.administration.api
 
 import com.calvintech.churchfinance.administration.service.ChurchService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
@@ -17,35 +22,103 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/v1/churches")
+@Tag(
+    name = "Churches",
+    description =
+        "Manage churches (tenants) within the system. A church is the top-level " +
+            "tenant boundary; almost all other resources are scoped to a church.",
+)
 class ChurchController(
     private val churchService: ChurchService,
 ) {
     @GetMapping("/{id}")
+    @Operation(
+        summary = "Get a church by id",
+        description = "Returns the church identified by the supplied UUID.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Church found"),
+            ApiResponse(responseCode = "404", description = "Church not found", content = []),
+        ],
+    )
     fun get(
+        @Parameter(description = "Identifier of the church", required = true)
         @PathVariable id: UUID,
     ): ChurchResponse = churchService.get(id)
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "Create a church",
+        description = "Registers a new church (tenant). The created church is returned in an `ACTIVE` state.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "201", description = "Church created"),
+            ApiResponse(responseCode = "400", description = "Validation failure", content = []),
+        ],
+    )
     fun create(
         @Valid @RequestBody request: CreateChurchRequest,
     ): ChurchResponse = churchService.create(request)
 
     @PutMapping("/{id}")
+    @Operation(
+        summary = "Update a church",
+        description =
+            "Updates a church's mutable attributes. Optimistic locking is enforced via the " +
+                "`version` field on the request body — supply the current version returned by the most recent read.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Church updated"),
+            ApiResponse(responseCode = "400", description = "Validation failure", content = []),
+            ApiResponse(responseCode = "404", description = "Church not found", content = []),
+            ApiResponse(responseCode = "409", description = "Optimistic locking conflict", content = []),
+        ],
+    )
     fun update(
+        @Parameter(description = "Identifier of the church", required = true)
         @PathVariable id: UUID,
         @Valid @RequestBody request: UpdateChurchRequest,
     ): ChurchResponse = churchService.update(id, request)
 
     @PatchMapping("/{id}/deactivate")
+    @Operation(
+        summary = "Deactivate a church",
+        description = "Marks the church as inactive. Requires the current `version` for optimistic locking.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Church deactivated"),
+            ApiResponse(responseCode = "404", description = "Church not found", content = []),
+            ApiResponse(responseCode = "409", description = "Optimistic locking conflict", content = []),
+        ],
+    )
     fun deactivate(
+        @Parameter(description = "Identifier of the church", required = true)
         @PathVariable id: UUID,
+        @Parameter(description = "Current version of the church for optimistic locking", required = true)
         @RequestParam version: Long,
     ): ChurchResponse = churchService.deactivate(id, version)
 
     @PatchMapping("/{id}/activate")
+    @Operation(
+        summary = "Activate a church",
+        description = "Reactivates a previously deactivated church. Requires the current `version` for optimistic locking.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Church activated"),
+            ApiResponse(responseCode = "404", description = "Church not found", content = []),
+            ApiResponse(responseCode = "409", description = "Optimistic locking conflict", content = []),
+        ],
+    )
     fun activate(
+        @Parameter(description = "Identifier of the church", required = true)
         @PathVariable id: UUID,
+        @Parameter(description = "Current version of the church for optimistic locking", required = true)
         @RequestParam version: Long,
     ): ChurchResponse = churchService.activate(id, version)
 }

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/CreateTransactionCategoryRequest.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/CreateTransactionCategoryRequest.kt
@@ -1,0 +1,10 @@
+package com.calvintech.churchfinance.administration.api
+
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import jakarta.validation.constraints.NotBlank
+
+data class CreateTransactionCategoryRequest(
+    @field:NotBlank
+    val name: String,
+    val type: FinancialTransactionType,
+)

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
@@ -1,6 +1,11 @@
 package com.calvintech.churchfinance.administration.api
 
 import com.calvintech.churchfinance.administration.service.TransactionCategoryService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PathVariable
@@ -12,14 +17,32 @@ import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
 
 @RestController
-@RequestMapping("/api/v1/transaction-categories")
+@RequestMapping("/api/v1/churches/{churchId}/transaction-categories")
+@Tag(
+    name = "Transaction Categories",
+    description =
+        "Manage transaction categories used to classify financial transactions " +
+            "(e.g. tithes, offerings, utilities). Categories are scoped to a church.",
+)
 class TransactionCategoryController(
     private val transactionCategoryService: TransactionCategoryService,
 ) {
-    @PostMapping("/{id}")
+    @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
+    @Operation(
+        summary = "Create a transaction category",
+        description = "Creates a new transaction category for the specified church.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "201", description = "Transaction category created"),
+            ApiResponse(responseCode = "400", description = "Validation failure", content = []),
+            ApiResponse(responseCode = "404", description = "Church not found", content = []),
+        ],
+    )
     fun create(
-        @PathVariable id: UUID,
+        @Parameter(description = "Identifier of the church the category belongs to", required = true)
+        @PathVariable churchId: UUID,
         @Valid @RequestBody request: CreateTransactionCategoryRequest,
-    ) = transactionCategoryService.create(id, request)
+    ): TransactionCategoryResponse = transactionCategoryService.create(churchId, request)
 }

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
@@ -1,0 +1,25 @@
+package com.calvintech.churchfinance.administration.api
+
+import com.calvintech.churchfinance.administration.service.TransactionCategoryService
+import jakarta.validation.Valid
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@RequestMapping("/api/v1/transaction-categories")
+class TransactionCategoryController(
+    private val transactionCategoryService: TransactionCategoryService,
+) {
+    @PostMapping("/{id}")
+    @ResponseStatus(HttpStatus.CREATED)
+    fun create(
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: CreateTransactionCategoryRequest,
+    ) = transactionCategoryService.create(id, request)
+}

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
@@ -120,6 +120,7 @@ class TransactionCategoryController(
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "Category deactivated"),
+            ApiResponse(responseCode = "400", description = "Missing required `version` parameter", content = []),
             ApiResponse(responseCode = "404", description = "Transaction category not found", content = []),
             ApiResponse(responseCode = "409", description = "Optimistic locking conflict", content = []),
         ],
@@ -141,6 +142,7 @@ class TransactionCategoryController(
     @ApiResponses(
         value = [
             ApiResponse(responseCode = "200", description = "Category activated"),
+            ApiResponse(responseCode = "400", description = "Missing required `version` parameter", content = []),
             ApiResponse(responseCode = "404", description = "Transaction category not found", content = []),
             ApiResponse(responseCode = "409", description = "Optimistic locking conflict", content = []),
         ],

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -45,4 +46,22 @@ class TransactionCategoryController(
         @PathVariable churchId: UUID,
         @Valid @RequestBody request: CreateTransactionCategoryRequest,
     ): TransactionCategoryResponse = transactionCategoryService.create(churchId, request)
+
+    @GetMapping("/{id}")
+    @Operation(
+        summary = "Get a transaction category by id",
+        description = "Returns the transaction category identified by its UUID, scoped to the supplied church.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Transaction category found"),
+            ApiResponse(responseCode = "404", description = "Transaction category not found", content = []),
+        ],
+    )
+    fun get(
+        @Parameter(description = "Identifier of the church the category belongs to", required = true)
+        @PathVariable churchId: UUID,
+        @Parameter(description = "Identifier of the transaction category", required = true)
+        @PathVariable id: UUID,
+    ): TransactionCategoryResponse = transactionCategoryService.get(churchId, id)
 }

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
@@ -110,4 +111,46 @@ class TransactionCategoryController(
         @PathVariable id: UUID,
         @Valid @RequestBody request: UpdateTransactionCategoryRequest,
     ): TransactionCategoryResponse = transactionCategoryService.update(churchId, id, request)
+
+    @PatchMapping("/{id}/deactivate")
+    @Operation(
+        summary = "Deactivate a transaction category",
+        description = "Marks the category as INACTIVE. Requires the current `version` for optimistic locking.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Category deactivated"),
+            ApiResponse(responseCode = "404", description = "Transaction category not found", content = []),
+            ApiResponse(responseCode = "409", description = "Optimistic locking conflict", content = []),
+        ],
+    )
+    fun deactivate(
+        @Parameter(description = "Identifier of the church", required = true)
+        @PathVariable churchId: UUID,
+        @Parameter(description = "Identifier of the transaction category", required = true)
+        @PathVariable id: UUID,
+        @Parameter(description = "Current version for optimistic locking", required = true)
+        @RequestParam version: Long,
+    ): TransactionCategoryResponse = transactionCategoryService.deactivate(churchId, id, version)
+
+    @PatchMapping("/{id}/activate")
+    @Operation(
+        summary = "Activate a transaction category",
+        description = "Marks the category as ACTIVE. Requires the current `version` for optimistic locking.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Category activated"),
+            ApiResponse(responseCode = "404", description = "Transaction category not found", content = []),
+            ApiResponse(responseCode = "409", description = "Optimistic locking conflict", content = []),
+        ],
+    )
+    fun activate(
+        @Parameter(description = "Identifier of the church", required = true)
+        @PathVariable churchId: UUID,
+        @Parameter(description = "Identifier of the transaction category", required = true)
+        @PathVariable id: UUID,
+        @Parameter(description = "Current version for optimistic locking", required = true)
+        @RequestParam version: Long,
+    ): TransactionCategoryResponse = transactionCategoryService.activate(churchId, id, version)
 }

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
@@ -1,6 +1,7 @@
 package com.calvintech.churchfinance.administration.api
 
 import com.calvintech.churchfinance.administration.service.TransactionCategoryService
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import java.util.UUID
@@ -46,6 +48,28 @@ class TransactionCategoryController(
         @PathVariable churchId: UUID,
         @Valid @RequestBody request: CreateTransactionCategoryRequest,
     ): TransactionCategoryResponse = transactionCategoryService.create(churchId, request)
+
+    @GetMapping
+    @Operation(
+        summary = "List transaction categories for a church",
+        description =
+            "Returns categories for the supplied church. Defaults to ACTIVE only; use `status=ALL` or " +
+                "`status=INACTIVE` to broaden, and `type=INCOME` or `type=EXPENDITURE` to narrow.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Categories returned"),
+            ApiResponse(responseCode = "404", description = "Church not found", content = []),
+        ],
+    )
+    fun list(
+        @Parameter(description = "Identifier of the church", required = true)
+        @PathVariable churchId: UUID,
+        @Parameter(description = "Status filter (default ACTIVE)")
+        @RequestParam(defaultValue = "ACTIVE") status: TransactionCategoryStatusFilter,
+        @Parameter(description = "Optional transaction type filter")
+        @RequestParam(required = false) type: FinancialTransactionType?,
+    ): List<TransactionCategoryResponse> = transactionCategoryService.list(churchId, status, type)
 
     @GetMapping("/{id}")
     @Operation(

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
@@ -88,4 +89,25 @@ class TransactionCategoryController(
         @Parameter(description = "Identifier of the transaction category", required = true)
         @PathVariable id: UUID,
     ): TransactionCategoryResponse = transactionCategoryService.get(churchId, id)
+
+    @PutMapping("/{id}")
+    @Operation(
+        summary = "Update a transaction category",
+        description = "Updates the category's name. Type is immutable. Requires the current `version` for optimistic locking.",
+    )
+    @ApiResponses(
+        value = [
+            ApiResponse(responseCode = "200", description = "Transaction category updated"),
+            ApiResponse(responseCode = "400", description = "Validation failure", content = []),
+            ApiResponse(responseCode = "404", description = "Transaction category not found", content = []),
+            ApiResponse(responseCode = "409", description = "Name conflict or optimistic locking conflict", content = []),
+        ],
+    )
+    fun update(
+        @Parameter(description = "Identifier of the church", required = true)
+        @PathVariable churchId: UUID,
+        @Parameter(description = "Identifier of the transaction category", required = true)
+        @PathVariable id: UUID,
+        @Valid @RequestBody request: UpdateTransactionCategoryRequest,
+    ): TransactionCategoryResponse = transactionCategoryService.update(churchId, id, request)
 }

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryResponse.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryResponse.kt
@@ -1,0 +1,11 @@
+package com.calvintech.churchfinance.administration.api
+
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import java.util.UUID
+
+data class TransactionCategoryResponse(
+    val id: UUID,
+    val name: String,
+    val type: FinancialTransactionType,
+    val version: Long,
+)

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryResponse.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryResponse.kt
@@ -1,5 +1,6 @@
 package com.calvintech.churchfinance.administration.api
 
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
 import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
 import java.util.UUID
 
@@ -7,5 +8,6 @@ data class TransactionCategoryResponse(
     val id: UUID,
     val name: String,
     val type: FinancialTransactionType,
+    val status: TransactionCategoryStatus,
     val version: Long,
 )

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryStatusFilter.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryStatusFilter.kt
@@ -1,0 +1,17 @@
+package com.calvintech.churchfinance.administration.api
+
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
+
+enum class TransactionCategoryStatusFilter {
+    ACTIVE,
+    INACTIVE,
+    ALL,
+    ;
+
+    fun matches(status: TransactionCategoryStatus): Boolean =
+        when (this) {
+            ALL -> true
+            ACTIVE -> status == TransactionCategoryStatus.ACTIVE
+            INACTIVE -> status == TransactionCategoryStatus.INACTIVE
+        }
+}

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/UpdateTransactionCategoryRequest.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/UpdateTransactionCategoryRequest.kt
@@ -1,0 +1,9 @@
+package com.calvintech.churchfinance.administration.api
+
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateTransactionCategoryRequest(
+    @field:NotBlank
+    val name: String,
+    val version: Long,
+)

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategory.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategory.kt
@@ -11,6 +11,7 @@ data class TransactionCategory(
     val addedBy: Ulid,
     val name: String,
     val transactionType: FinancialTransactionType,
+    val status: TransactionCategoryStatus = TransactionCategoryStatus.ACTIVE,
     val version: Long = 0,
 ) {
     init {

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNameConflictException.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNameConflictException.kt
@@ -1,0 +1,12 @@
+package com.calvintech.churchfinance.administration.domain
+
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import java.util.UUID
+
+class TransactionCategoryNameConflictException(
+    val churchId: UUID,
+    val name: String,
+    val type: FinancialTransactionType,
+) : RuntimeException(
+        "A category named '$name' already exists for $type in this church.",
+    )

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNotFoundException.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.calvintech.churchfinance.administration.domain
+
+import java.util.UUID
+
+class TransactionCategoryNotFoundException(
+    id: UUID,
+) : RuntimeException("Transaction category not found: $id")

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryStatus.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryStatus.kt
@@ -1,0 +1,6 @@
+package com.calvintech.churchfinance.administration.domain
+
+enum class TransactionCategoryStatus {
+    ACTIVE,
+    INACTIVE,
+}

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryJpaEntity.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryJpaEntity.kt
@@ -1,5 +1,6 @@
 package com.calvintech.churchfinance.administration.persistence
 
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
 import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -21,6 +22,8 @@ class TransactionCategoryJpaEntity(
     var name: String,
     @Enumerated(EnumType.STRING)
     var transactionType: FinancialTransactionType,
+    @Enumerated(EnumType.STRING)
+    var status: TransactionCategoryStatus = TransactionCategoryStatus.ACTIVE,
     @Version
     var version: Long = 0,
 )

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryMapper.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryMapper.kt
@@ -14,6 +14,7 @@ class TransactionCategoryMapper {
             name = entity.name,
             addedBy = Ulid.from(entity.addedBy),
             transactionType = entity.transactionType,
+            status = entity.status,
             version = entity.version,
         )
 
@@ -25,6 +26,7 @@ class TransactionCategoryMapper {
             addedBy = category.addedBy.toUuid(),
             name = category.name,
             transactionType = category.transactionType,
+            status = category.status,
             version = category.version,
         )
 }

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryRepository.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryRepository.kt
@@ -1,6 +1,15 @@
 package com.calvintech.churchfinance.administration.persistence
 
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface TransactionCategoryRepository : JpaRepository<TransactionCategoryJpaEntity, UUID>
+interface TransactionCategoryRepository : JpaRepository<TransactionCategoryJpaEntity, UUID> {
+    fun findByChurchIdAndNameAndTransactionType(
+        churchId: UUID,
+        name: String,
+        transactionType: FinancialTransactionType,
+    ): TransactionCategoryJpaEntity?
+
+    fun findAllByChurchId(churchId: UUID): List<TransactionCategoryJpaEntity>
+}

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
@@ -1,0 +1,50 @@
+package com.calvintech.churchfinance.administration.service
+
+import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
+import com.calvintech.churchfinance.administration.api.TransactionCategoryResponse
+import com.calvintech.churchfinance.administration.domain.TransactionCategory
+import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
+import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
+import com.calvintech.churchfinance.shared.service.CurrentUserProvider
+import com.github.f4b6a3.ulid.Ulid
+import com.github.f4b6a3.ulid.UlidCreator
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class TransactionCategoryService(
+    private val mapper: TransactionCategoryMapper,
+    private val repository: TransactionCategoryRepository,
+    private val userProvider: CurrentUserProvider,
+) {
+    fun create(
+        churchId: UUID,
+        createTransactionCategoryRequest: CreateTransactionCategoryRequest,
+    ): TransactionCategoryResponse {
+        val transactionCategory =
+            TransactionCategory(
+                id = UlidCreator.getUlid(),
+                churchId = Ulid.from(churchId),
+                createdAt = Instant.now(),
+                addedBy = userProvider.getCurrentUserId(),
+                name = createTransactionCategoryRequest.name,
+                transactionType = createTransactionCategoryRequest.type,
+            )
+
+        return saveAndRespond(transactionCategory)
+    }
+
+    private fun saveAndRespond(transactionCategory: TransactionCategory): TransactionCategoryResponse {
+        val persisted = repository.save(mapper.toJpaEntity(transactionCategory))
+        return toResponse(mapper.toDomain(persisted))
+    }
+
+    private fun toResponse(transactionCategory: TransactionCategory): TransactionCategoryResponse =
+        TransactionCategoryResponse(
+            id = transactionCategory.id.toUuid(),
+            name = transactionCategory.name,
+            type = transactionCategory.transactionType,
+            version = transactionCategory.version,
+        )
+}

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
@@ -45,6 +45,7 @@ class TransactionCategoryService(
             id = transactionCategory.id.toUuid(),
             name = transactionCategory.name,
             type = transactionCategory.transactionType,
+            status = transactionCategory.status,
             version = transactionCategory.version,
         )
 }

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
@@ -2,6 +2,7 @@ package com.calvintech.churchfinance.administration.service
 
 import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
 import com.calvintech.churchfinance.administration.api.TransactionCategoryResponse
+import com.calvintech.churchfinance.administration.api.TransactionCategoryStatusFilter
 import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
@@ -53,6 +54,21 @@ class TransactionCategoryService(
         churchId: UUID,
         id: UUID,
     ): TransactionCategoryResponse = toResponse(findCategoryScopedToChurch(churchId, id))
+
+    fun list(
+        churchId: UUID,
+        status: TransactionCategoryStatusFilter,
+        type: FinancialTransactionType?,
+    ): List<TransactionCategoryResponse> {
+        requireChurchExists(churchId)
+        return repository
+            .findAllByChurchId(churchId)
+            .map(mapper::toDomain)
+            .filter { status.matches(it.status) }
+            .filter { type == null || it.transactionType == type }
+            .sortedBy { it.name }
+            .map(::toResponse)
+    }
 
     private fun findCategoryScopedToChurch(
         churchId: UUID,

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
@@ -3,6 +3,7 @@ package com.calvintech.churchfinance.administration.service
 import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
 import com.calvintech.churchfinance.administration.api.TransactionCategoryResponse
 import com.calvintech.churchfinance.administration.api.TransactionCategoryStatusFilter
+import com.calvintech.churchfinance.administration.api.UpdateTransactionCategoryRequest
 import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
@@ -54,6 +55,24 @@ class TransactionCategoryService(
         churchId: UUID,
         id: UUID,
     ): TransactionCategoryResponse = toResponse(findCategoryScopedToChurch(churchId, id))
+
+    fun update(
+        churchId: UUID,
+        id: UUID,
+        req: UpdateTransactionCategoryRequest,
+    ): TransactionCategoryResponse {
+        val existing = findCategoryScopedToChurch(churchId, id)
+        if (existing.name != req.name) {
+            requireNameAvailable(
+                churchId = churchId,
+                name = req.name,
+                type = existing.transactionType,
+                excludingId = id,
+            )
+        }
+        val updated = existing.copy(name = req.name, version = req.version)
+        return saveAndRespond(updated)
+    }
 
     fun list(
         churchId: UUID,

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
@@ -4,9 +4,11 @@ import com.calvintech.churchfinance.administration.api.CreateTransactionCategory
 import com.calvintech.churchfinance.administration.api.TransactionCategoryResponse
 import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
 import com.calvintech.churchfinance.administration.persistence.ChurchRepository
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
 import com.calvintech.churchfinance.shared.service.CurrentUserProvider
 import com.github.f4b6a3.ulid.Ulid
 import com.github.f4b6a3.ulid.UlidCreator
@@ -26,6 +28,12 @@ class TransactionCategoryService(
         createTransactionCategoryRequest: CreateTransactionCategoryRequest,
     ): TransactionCategoryResponse {
         requireChurchExists(churchId)
+        requireNameAvailable(
+            churchId = churchId,
+            name = createTransactionCategoryRequest.name,
+            type = createTransactionCategoryRequest.type,
+            excludingId = null,
+        )
 
         val transactionCategory =
             TransactionCategory(
@@ -43,6 +51,23 @@ class TransactionCategoryService(
     private fun requireChurchExists(churchId: UUID) {
         if (!churchRepository.existsById(churchId)) {
             throw ChurchNotFoundException(churchId)
+        }
+    }
+
+    private fun requireNameAvailable(
+        churchId: UUID,
+        name: String,
+        type: FinancialTransactionType,
+        excludingId: UUID?,
+    ) {
+        val conflict =
+            repository.findByChurchIdAndNameAndTransactionType(
+                churchId = churchId,
+                name = name,
+                transactionType = type,
+            )
+        if (conflict != null && conflict.id != excludingId) {
+            throw TransactionCategoryNameConflictException(churchId, name, type)
         }
     }
 

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
@@ -57,21 +57,36 @@ class TransactionCategoryService(
         id: UUID,
     ): TransactionCategoryResponse = toResponse(findCategoryScopedToChurch(churchId, id))
 
+    fun list(
+        churchId: UUID,
+        status: TransactionCategoryStatusFilter,
+        type: FinancialTransactionType?,
+    ): List<TransactionCategoryResponse> {
+        requireChurchExists(churchId)
+        return repository
+            .findAllByChurchId(churchId)
+            .map(mapper::toDomain)
+            .filter { status.matches(it.status) }
+            .filter { type == null || it.transactionType == type }
+            .sortedBy { it.name }
+            .map(::toResponse)
+    }
+
     fun update(
         churchId: UUID,
         id: UUID,
-        req: UpdateTransactionCategoryRequest,
+        updateTransactionCategoryRequest: UpdateTransactionCategoryRequest,
     ): TransactionCategoryResponse {
         val existing = findCategoryScopedToChurch(churchId, id)
-        if (existing.name != req.name) {
+        if (existing.name != updateTransactionCategoryRequest.name) {
             requireNameAvailable(
                 churchId = churchId,
-                name = req.name,
+                name = updateTransactionCategoryRequest.name,
                 type = existing.transactionType,
                 excludingId = id,
             )
         }
-        val updated = existing.copy(name = req.name, version = req.version)
+        val updated = existing.copy(name = updateTransactionCategoryRequest.name, version = updateTransactionCategoryRequest.version)
         return saveAndRespond(updated)
     }
 
@@ -95,21 +110,6 @@ class TransactionCategoryService(
         return saveAndRespond(updated)
     }
 
-    fun list(
-        churchId: UUID,
-        status: TransactionCategoryStatusFilter,
-        type: FinancialTransactionType?,
-    ): List<TransactionCategoryResponse> {
-        requireChurchExists(churchId)
-        return repository
-            .findAllByChurchId(churchId)
-            .map(mapper::toDomain)
-            .filter { status.matches(it.status) }
-            .filter { type == null || it.transactionType == type }
-            .sortedBy { it.name }
-            .map(::toResponse)
-    }
-
     private fun findCategoryScopedToChurch(
         churchId: UUID,
         id: UUID,
@@ -128,6 +128,10 @@ class TransactionCategoryService(
         }
     }
 
+    // `excludingId` lets the update flow ignore the row being updated when it queries by the new name.
+    // Today the caller (update) only invokes this helper when the name actually changes, so the query
+    // cannot return the row being updated — but keeping the parameter preserves the rule's semantics
+    // and the DB constraint remains the safety net for the TOCTOU race regardless.
     private fun requireNameAvailable(
         churchId: UUID,
         name: String,

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
@@ -2,7 +2,9 @@ package com.calvintech.churchfinance.administration.service
 
 import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
 import com.calvintech.churchfinance.administration.api.TransactionCategoryResponse
+import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
+import com.calvintech.churchfinance.administration.persistence.ChurchRepository
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
 import com.calvintech.churchfinance.shared.service.CurrentUserProvider
@@ -17,11 +19,14 @@ class TransactionCategoryService(
     private val mapper: TransactionCategoryMapper,
     private val repository: TransactionCategoryRepository,
     private val userProvider: CurrentUserProvider,
+    private val churchRepository: ChurchRepository,
 ) {
     fun create(
         churchId: UUID,
         createTransactionCategoryRequest: CreateTransactionCategoryRequest,
     ): TransactionCategoryResponse {
+        requireChurchExists(churchId)
+
         val transactionCategory =
             TransactionCategory(
                 id = UlidCreator.getUlid(),
@@ -33,6 +38,12 @@ class TransactionCategoryService(
             )
 
         return saveAndRespond(transactionCategory)
+    }
+
+    private fun requireChurchExists(churchId: UUID) {
+        if (!churchRepository.existsById(churchId)) {
+            throw ChurchNotFoundException(churchId)
+        }
     }
 
     private fun saveAndRespond(transactionCategory: TransactionCategory): TransactionCategoryResponse {

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
@@ -8,6 +8,7 @@ import com.calvintech.churchfinance.administration.domain.ChurchNotFoundExceptio
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryNotFoundException
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
 import com.calvintech.churchfinance.administration.persistence.ChurchRepository
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
@@ -71,6 +72,26 @@ class TransactionCategoryService(
             )
         }
         val updated = existing.copy(name = req.name, version = req.version)
+        return saveAndRespond(updated)
+    }
+
+    fun deactivate(
+        churchId: UUID,
+        id: UUID,
+        version: Long,
+    ): TransactionCategoryResponse {
+        val existing = findCategoryScopedToChurch(churchId, id)
+        val updated = existing.copy(status = TransactionCategoryStatus.INACTIVE, version = version)
+        return saveAndRespond(updated)
+    }
+
+    fun activate(
+        churchId: UUID,
+        id: UUID,
+        version: Long,
+    ): TransactionCategoryResponse {
+        val existing = findCategoryScopedToChurch(churchId, id)
+        val updated = existing.copy(status = TransactionCategoryStatus.ACTIVE, version = version)
         return saveAndRespond(updated)
     }
 

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt
@@ -5,6 +5,7 @@ import com.calvintech.churchfinance.administration.api.TransactionCategoryRespon
 import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryNotFoundException
 import com.calvintech.churchfinance.administration.persistence.ChurchRepository
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
@@ -46,6 +47,23 @@ class TransactionCategoryService(
             )
 
         return saveAndRespond(transactionCategory)
+    }
+
+    fun get(
+        churchId: UUID,
+        id: UUID,
+    ): TransactionCategoryResponse = toResponse(findCategoryScopedToChurch(churchId, id))
+
+    private fun findCategoryScopedToChurch(
+        churchId: UUID,
+        id: UUID,
+    ): TransactionCategory {
+        val entity = repository.findById(id).orElseThrow { TransactionCategoryNotFoundException(id) }
+        val domain = mapper.toDomain(entity)
+        if (domain.churchId.toUuid() != churchId) {
+            throw TransactionCategoryNotFoundException(id)
+        }
+        return domain
     }
 
     private fun requireChurchExists(churchId: UUID) {

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/shared/api/GlobalExceptionHandler.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/shared/api/GlobalExceptionHandler.kt
@@ -1,6 +1,9 @@
 package com.calvintech.churchfinance.shared.api
 
 import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryNotFoundException
+import org.springframework.dao.DataIntegrityViolationException
 import org.springframework.http.HttpStatus
 import org.springframework.orm.ObjectOptimisticLockingFailureException
 import org.springframework.web.bind.MethodArgumentNotValidException
@@ -13,6 +16,16 @@ class GlobalExceptionHandler {
     @ExceptionHandler(ChurchNotFoundException::class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
     fun handleChurchNotFound(ex: ChurchNotFoundException): ErrorResponse = ErrorResponse(ex.message ?: "Church not found")
+
+    @ExceptionHandler(TransactionCategoryNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun handleTransactionCategoryNotFound(ex: TransactionCategoryNotFoundException): ErrorResponse =
+        ErrorResponse(ex.message ?: "Transaction category not found")
+
+    @ExceptionHandler(TransactionCategoryNameConflictException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    fun handleTransactionCategoryNameConflict(ex: TransactionCategoryNameConflictException): ErrorResponse =
+        ErrorResponse(ex.message ?: "Category name conflict")
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -27,4 +40,8 @@ class GlobalExceptionHandler {
     @ExceptionHandler(ObjectOptimisticLockingFailureException::class)
     @ResponseStatus(HttpStatus.CONFLICT)
     fun handleOptimisticLock(): ErrorResponse = ErrorResponse("Someone else has made a change. Please refresh and try again.")
+
+    @ExceptionHandler(DataIntegrityViolationException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    fun handleDataIntegrityViolation(): ErrorResponse = ErrorResponse("Conflict — please refresh and try again.")
 }

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/shared/api/OpenApiConfig.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/shared/api/OpenApiConfig.kt
@@ -1,0 +1,34 @@
+package com.calvintech.churchfinance.shared.api
+
+import org.springdoc.core.models.GroupedOpenApi
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * Groups OpenAPI operations by DDD aggregate. Each group surfaces as a separate
+ * entry in the Swagger UI "Select a definition" dropdown and is also exposed at
+ * `/v3/api-docs/<group>` for per-aggregate client codegen.
+ *
+ * Add a new bean here whenever a new aggregate exposes its first endpoint —
+ * one line per aggregate, matched by package pattern.
+ */
+@Configuration
+class OpenApiConfig {
+    @Bean
+    fun allApi(): GroupedOpenApi =
+        GroupedOpenApi
+            .builder()
+            .group("all")
+            .displayName("All APIs")
+            .packagesToScan("com.calvintech.churchfinance")
+            .build()
+
+    @Bean
+    fun administrationApi(): GroupedOpenApi =
+        GroupedOpenApi
+            .builder()
+            .group("administration")
+            .displayName("Administration")
+            .packagesToScan("com.calvintech.churchfinance.administration")
+            .build()
+}

--- a/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/shared/service/StubCurrentUserProvider.kt
+++ b/church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/shared/service/StubCurrentUserProvider.kt
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
 @Component
-@Profile("local", "test")
+@Profile("local", "test", "docker")
 class StubCurrentUserProvider : CurrentUserProvider {
     override fun getCurrentUserId(): Ulid = UlidCreator.getUlid()
 }

--- a/church-finance-backend/src/main/resources/application-local.yaml.example
+++ b/church-finance-backend/src/main/resources/application-local.yaml.example
@@ -1,5 +1,5 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/church_finance
-    username:
-    password:
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/app}
+    username: ${DATABASE_USERNAME:}
+    password: ${DATABASE_PASSWORD:}

--- a/church-finance-backend/src/main/resources/application.yaml
+++ b/church-finance-backend/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   application:
     name: Church Finance
   datasource:
-    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/church_finance}
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/app}
     username: ${DATABASE_USERNAME}
     password: ${DATABASE_PASSWORD}
   jpa:

--- a/church-finance-backend/src/main/resources/db/migration/V3__transaction_category_status_and_unique.sql
+++ b/church-finance-backend/src/main/resources/db/migration/V3__transaction_category_status_and_unique.sql
@@ -1,0 +1,9 @@
+ALTER TABLE church_finance.transaction_category
+    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE';
+
+ALTER TABLE church_finance.transaction_category
+    DROP CONSTRAINT transaction_category_church_name_unique;
+
+ALTER TABLE church_finance.transaction_category
+    ADD CONSTRAINT transaction_category_church_name_type_unique
+        UNIQUE (church_id, name, transaction_type);

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/ChurchControllerIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/ChurchControllerIntegrationTest.kt
@@ -32,7 +32,7 @@ class ChurchControllerIntegrationTest {
 
     private fun extractVersion(responseBody: String): String = objectMapper.readTree(responseBody).get("version").asString()
 
-    private fun createChurch(name: String = "Grace Church"): String {
+    private fun createChurch(name: String = "Our Saviour Lutheran Church"): String {
         val result =
             mockMvc
                 .perform(
@@ -51,9 +51,9 @@ class ChurchControllerIntegrationTest {
             .perform(
                 post("/api/v1/churches")
                     .contentType(MediaType.APPLICATION_JSON)
-                    .content("""{"name": "Grace Church"}"""),
+                    .content("""{"name": "Our Saviour Lutheran Church"}"""),
             ).andExpect(status().isCreated)
-            .andExpect(jsonPath("$.name").value("Grace Church"))
+            .andExpect(jsonPath("$.name").value("Our Saviour Lutheran Church"))
             .andExpect(jsonPath("$.status").value(ChurchStatus.ACTIVE.name))
             .andExpect(jsonPath("$.id").exists())
             .andExpect(jsonPath("$.version").value(0))
@@ -82,14 +82,14 @@ class ChurchControllerIntegrationTest {
 
     @Test
     fun `GET should return an existing church`() {
-        val body = createChurch("Grace Church")
+        val body = createChurch("Our Saviour Lutheran Church")
         val id = extractId(body)
 
         mockMvc
             .perform(get("/api/v1/churches/$id"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value(id))
-            .andExpect(jsonPath("$.name").value("Grace Church"))
+            .andExpect(jsonPath("$.name").value("Our Saviour Lutheran Church"))
             .andExpect(jsonPath("$.status").value(ChurchStatus.ACTIVE.name))
     }
 
@@ -104,7 +104,7 @@ class ChurchControllerIntegrationTest {
 
     @Test
     fun `PUT should update the church name`() {
-        val body = createChurch("Grace Church")
+        val body = createChurch("Our Saviour Lutheran Church")
         val id = extractId(body)
 
         mockMvc
@@ -119,7 +119,7 @@ class ChurchControllerIntegrationTest {
 
     @Test
     fun `PUT should return 400 with error message when name is blank`() {
-        val body = createChurch("Grace Church")
+        val body = createChurch("Our Saviour Lutheran Church")
         val id = extractId(body)
 
         mockMvc
@@ -145,7 +145,7 @@ class ChurchControllerIntegrationTest {
 
     @Test
     fun `PATCH deactivate should set status to INACTIVE`() {
-        val body = createChurch("Grace Church")
+        val body = createChurch("Our Saviour Lutheran Church")
         val id = extractId(body)
         val version = extractVersion(body)
 
@@ -168,7 +168,7 @@ class ChurchControllerIntegrationTest {
 
     @Test
     fun `PATCH activate should set status to ACTIVE`() {
-        val body = createChurch("Grace Church")
+        val body = createChurch("Our Saviour Lutheran Church")
         val id = extractId(body)
 
         val deactivateResult =
@@ -188,7 +188,7 @@ class ChurchControllerIntegrationTest {
 
     @Test
     fun `PUT should return 409 when version is stale`() {
-        val body = createChurch("Grace Church")
+        val body = createChurch("Our Saviour Lutheran Church")
         val id = extractId(body)
 
         mockMvc

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -42,7 +42,7 @@ class TransactionCategoryIntegrationTest {
         val churchId = UUID.fromString(createChurch())
         mockMvc
             .perform(
-                post("/api/v1/transaction-categories/{id}", churchId)
+                post("/api/v1/churches/{churchId}/transaction-categories", churchId)
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"name": "Offerings", "type": "INCOME"}"""),
             ).andExpect(status().isCreated)

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -1,0 +1,54 @@
+package com.calvintech.churchfinance.administration.api
+
+import com.calvintech.churchfinance.TestcontainersConfiguration
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.testcontainers.context.ImportTestcontainers
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import tools.jackson.databind.ObjectMapper
+import java.util.UUID
+import kotlin.test.Test
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ImportTestcontainers(TestcontainersConfiguration::class)
+class TransactionCategoryIntegrationTest {
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @Autowired
+    lateinit var objectMapper: ObjectMapper
+
+    private fun createChurch(name: String = "Grace Church"): String {
+        val result =
+            mockMvc
+                .perform(
+                    post("/api/v1/churches")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"name": "$name"}"""),
+                ).andExpect(status().isCreated)
+                .andReturn()
+        return objectMapper.readTree(result.response.contentAsString).get("id").asString()
+    }
+
+    @Test
+    fun `POST should create a transaction category and return 201`() {
+        val churchId = UUID.fromString(createChurch())
+        mockMvc
+            .perform(
+                post("/api/v1/transaction-categories/{id}", churchId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Offerings", "type": "INCOME"}"""),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.name").value("Offerings"))
+            .andExpect(jsonPath("$.type").value(FinancialTransactionType.INCOME.name))
+            .andExpect(jsonPath("$.id").exists())
+            .andExpect(jsonPath("$.version").value(0))
+    }
+}

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -25,7 +25,7 @@ class TransactionCategoryIntegrationTest {
     @Autowired
     lateinit var objectMapper: ObjectMapper
 
-    private fun createChurch(name: String = "Grace Church"): String {
+    private fun createChurch(name: String = "Our Saviour Lutheran Church"): String {
         val result =
             mockMvc
                 .perform(

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -48,6 +48,7 @@ class TransactionCategoryIntegrationTest {
             ).andExpect(status().isCreated)
             .andExpect(jsonPath("$.name").value("Offerings"))
             .andExpect(jsonPath("$.type").value(FinancialTransactionType.INCOME.name))
+            .andExpect(jsonPath("$.status").value("ACTIVE"))
             .andExpect(jsonPath("$.id").exists())
             .andExpect(jsonPath("$.version").value(0))
     }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -41,12 +41,14 @@ class TransactionCategoryIntegrationTest {
         name: String = "Offerings",
         type: String = "INCOME",
     ): String =
-        mockMvc.perform(
-            post("/api/v1/churches/{churchId}/transaction-categories", churchId)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"name": "$name", "type": "$type"}"""),
-        ).andExpect(status().isCreated)
-            .andReturn().response.contentAsString
+        mockMvc
+            .perform(
+                post("/api/v1/churches/{churchId}/transaction-categories", churchId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "$name", "type": "$type"}"""),
+            ).andExpect(status().isCreated)
+            .andReturn()
+            .response.contentAsString
 
     private fun extractId(body: String): String = objectMapper.readTree(body).get("id").asString()
 
@@ -106,5 +108,40 @@ class TransactionCategoryIntegrationTest {
         postCategory(churchId, "Tithes", "INCOME").andExpect(status().isCreated)
 
         postCategory(churchId, "Tithes", "EXPENDITURE").andExpect(status().isCreated)
+    }
+
+    @Test
+    fun `GET by id returns the category`() {
+        val churchId = UUID.fromString(createChurch())
+        val id = extractId(createCategoryAndReturnBody(churchId, "Tithes", "INCOME"))
+
+        mockMvc
+            .perform(get("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(id))
+            .andExpect(jsonPath("$.name").value("Tithes"))
+            .andExpect(jsonPath("$.type").value("INCOME"))
+            .andExpect(jsonPath("$.status").value("ACTIVE"))
+    }
+
+    @Test
+    fun `GET by id returns 404 when category does not exist`() {
+        val churchId = UUID.fromString(createChurch())
+        val unknownId = UUID.randomUUID()
+
+        mockMvc
+            .perform(get("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, unknownId))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `GET by id returns 404 when category belongs to a different church`() {
+        val churchOne = UUID.fromString(createChurch("Church One"))
+        val churchTwo = UUID.fromString(createChurch("Church Two"))
+        val id = extractId(createCategoryAndReturnBody(churchOne, "Tithes", "INCOME"))
+
+        mockMvc
+            .perform(get("/api/v1/churches/{churchId}/transaction-categories/{id}", churchTwo, id))
+            .andExpect(status().isNotFound)
     }
 }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -25,6 +25,16 @@ class TransactionCategoryIntegrationTest {
     @Autowired
     lateinit var objectMapper: ObjectMapper
 
+    private fun postCategory(
+        churchId: UUID,
+        name: String,
+        type: String,
+    ) = mockMvc.perform(
+        post("/api/v1/churches/{churchId}/transaction-categories", churchId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "$name", "type": "$type"}"""),
+    )
+
     private fun createChurch(name: String = "Our Saviour Lutheran Church"): String {
         val result =
             mockMvc
@@ -63,5 +73,23 @@ class TransactionCategoryIntegrationTest {
             .andExpect(jsonPath("$.status").value("ACTIVE"))
             .andExpect(jsonPath("$.id").exists())
             .andExpect(jsonPath("$.version").value(0))
+    }
+
+    @Test
+    fun `POST should return 409 when name already exists for the same type in the same church`() {
+        val churchId = UUID.fromString(createChurch())
+        postCategory(churchId, "Tithes", "INCOME").andExpect(status().isCreated)
+
+        postCategory(churchId, "Tithes", "INCOME")
+            .andExpect(status().isConflict)
+            .andExpect(jsonPath("$.message").exists())
+    }
+
+    @Test
+    fun `POST should return 201 when name exists but for a different type`() {
+        val churchId = UUID.fromString(createChurch())
+        postCategory(churchId, "Tithes", "INCOME").andExpect(status().isCreated)
+
+        postCategory(churchId, "Tithes", "EXPENDITURE").andExpect(status().isCreated)
     }
 }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -38,6 +38,18 @@ class TransactionCategoryIntegrationTest {
     }
 
     @Test
+    fun `POST should return 404 when church does not exist`() {
+        val unknownChurchId = UUID.randomUUID()
+        mockMvc
+            .perform(
+                post("/api/v1/churches/{churchId}/transaction-categories", unknownChurchId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Offerings", "type": "INCOME"}"""),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.message").exists())
+    }
+
+    @Test
     fun `POST should create a transaction category and return 201`() {
         val churchId = UUID.fromString(createChurch())
         mockMvc

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -2,6 +2,7 @@ package com.calvintech.churchfinance.administration.api
 
 import com.calvintech.churchfinance.TestcontainersConfiguration
 import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import org.hamcrest.Matchers.hasItems
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.testcontainers.context.ImportTestcontainers
@@ -143,5 +144,70 @@ class TransactionCategoryIntegrationTest {
         mockMvc
             .perform(get("/api/v1/churches/{churchId}/transaction-categories/{id}", churchTwo, id))
             .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `GET list returns only ACTIVE categories by default`() {
+        val churchId = UUID.fromString(createChurch())
+        val activeId = extractId(createCategoryAndReturnBody(churchId, "Tithes", "INCOME"))
+        val toDeactivateBody = createCategoryAndReturnBody(churchId, "Old", "INCOME")
+        val toDeactivateId = extractId(toDeactivateBody)
+        // We can't deactivate yet (Task 11). Insert it INACTIVE via PATCH route once it exists.
+        // For now, this test will be updated in Task 11 once deactivate exists.
+        // In this task, assert that the freshly created category appears in the default listing.
+        mockMvc
+            .perform(get("/api/v1/churches/{churchId}/transaction-categories", churchId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(2))
+            .andExpect(jsonPath("$[*].id", hasItems(activeId, toDeactivateId)))
+    }
+
+    @Test
+    fun `GET list returns empty list when church has no categories`() {
+        val churchId = UUID.fromString(createChurch())
+
+        mockMvc
+            .perform(get("/api/v1/churches/{churchId}/transaction-categories", churchId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(0))
+    }
+
+    @Test
+    fun `GET list returns 404 when church does not exist`() {
+        val unknownChurchId = UUID.randomUUID()
+
+        mockMvc
+            .perform(get("/api/v1/churches/{churchId}/transaction-categories", unknownChurchId))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `GET list with type=INCOME filters correctly`() {
+        val churchId = UUID.fromString(createChurch())
+        createCategoryAndReturnBody(churchId, "Tithes", "INCOME")
+        createCategoryAndReturnBody(churchId, "Bills", "EXPENDITURE")
+
+        mockMvc
+            .perform(
+                get("/api/v1/churches/{churchId}/transaction-categories", churchId)
+                    .param("type", "INCOME"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].name").value("Tithes"))
+    }
+
+    @Test
+    fun `GET list sorts by name ascending`() {
+        val churchId = UUID.fromString(createChurch())
+        createCategoryAndReturnBody(churchId, "Zebra", "INCOME")
+        createCategoryAndReturnBody(churchId, "Apple", "INCOME")
+        createCategoryAndReturnBody(churchId, "Mango", "INCOME")
+
+        mockMvc
+            .perform(get("/api/v1/churches/{churchId}/transaction-categories", churchId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].name").value("Apple"))
+            .andExpect(jsonPath("$[1].name").value("Mango"))
+            .andExpect(jsonPath("$[2].name").value("Zebra"))
     }
 }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -2,7 +2,6 @@ package com.calvintech.churchfinance.administration.api
 
 import com.calvintech.churchfinance.TestcontainersConfiguration
 import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
-import org.hamcrest.Matchers.hasItems
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.testcontainers.context.ImportTestcontainers
@@ -10,6 +9,7 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -151,16 +151,19 @@ class TransactionCategoryIntegrationTest {
     fun `GET list returns only ACTIVE categories by default`() {
         val churchId = UUID.fromString(createChurch())
         val activeId = extractId(createCategoryAndReturnBody(churchId, "Tithes", "INCOME"))
-        val toDeactivateBody = createCategoryAndReturnBody(churchId, "Old", "INCOME")
-        val toDeactivateId = extractId(toDeactivateBody)
-        // We can't deactivate yet (Task 11). Insert it INACTIVE via PATCH route once it exists.
-        // For now, this test will be updated in Task 11 once deactivate exists.
-        // In this task, assert that the freshly created category appears in the default listing.
+        val toDeactivateId = extractId(createCategoryAndReturnBody(churchId, "Old", "INCOME"))
+
+        mockMvc
+            .perform(
+                patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchId, toDeactivateId)
+                    .param("version", "0"),
+            ).andExpect(status().isOk)
+
         mockMvc
             .perform(get("/api/v1/churches/{churchId}/transaction-categories", churchId))
             .andExpect(status().isOk)
-            .andExpect(jsonPath("$.length()").value(2))
-            .andExpect(jsonPath("$[*].id", hasItems(activeId, toDeactivateId)))
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].id").value(activeId))
     }
 
     @Test
@@ -301,5 +304,118 @@ class TransactionCategoryIntegrationTest {
             .andExpect(jsonPath("$[0].name").value("Apple"))
             .andExpect(jsonPath("$[1].name").value("Mango"))
             .andExpect(jsonPath("$[2].name").value("Zebra"))
+    }
+
+    @Test
+    fun `PATCH deactivate sets status to INACTIVE`() {
+        val churchId = UUID.fromString(createChurch())
+        val id = extractId(createCategoryAndReturnBody(churchId, "X", "INCOME"))
+
+        mockMvc
+            .perform(
+                patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchId, id)
+                    .param("version", "0"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("INACTIVE"))
+    }
+
+    @Test
+    fun `PATCH activate sets status to ACTIVE`() {
+        val churchId = UUID.fromString(createChurch())
+        val id = extractId(createCategoryAndReturnBody(churchId, "X", "INCOME"))
+
+        val deactivateBody =
+            mockMvc
+                .perform(
+                    patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchId, id)
+                        .param("version", "0"),
+                ).andExpect(status().isOk)
+                .andReturn()
+                .response.contentAsString
+
+        val newVersion = objectMapper.readTree(deactivateBody).get("version").asString()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/churches/{churchId}/transaction-categories/{id}/activate", churchId, id)
+                    .param("version", newVersion),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("ACTIVE"))
+    }
+
+    @Test
+    fun `PATCH deactivate returns 404 on unknown id`() {
+        val churchId = UUID.fromString(createChurch())
+        val unknownId = UUID.randomUUID()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchId, unknownId)
+                    .param("version", "0"),
+            ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `PATCH deactivate returns 404 on tenant mismatch`() {
+        val churchOne = UUID.fromString(createChurch("Church One"))
+        val churchTwo = UUID.fromString(createChurch("Church Two"))
+        val id = extractId(createCategoryAndReturnBody(churchOne, "X", "INCOME"))
+
+        mockMvc
+            .perform(
+                patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchTwo, id)
+                    .param("version", "0"),
+            ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `PATCH activate returns 404 on unknown id`() {
+        val churchId = UUID.fromString(createChurch())
+        val unknownId = UUID.randomUUID()
+
+        mockMvc
+            .perform(
+                patch("/api/v1/churches/{churchId}/transaction-categories/{id}/activate", churchId, unknownId)
+                    .param("version", "0"),
+            ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `PATCH activate returns 404 on tenant mismatch`() {
+        val churchOne = UUID.fromString(createChurch("Church One"))
+        val churchTwo = UUID.fromString(createChurch("Church Two"))
+        val id = extractId(createCategoryAndReturnBody(churchOne, "X", "INCOME"))
+
+        mockMvc
+            .perform(
+                patch("/api/v1/churches/{churchId}/transaction-categories/{id}/activate", churchTwo, id)
+                    .param("version", "0"),
+            ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `Deactivated category is excluded from default list but included with status=ALL`() {
+        val churchId = UUID.fromString(createChurch())
+        val activeId = extractId(createCategoryAndReturnBody(churchId, "Active", "INCOME"))
+        val toDeactivateId = extractId(createCategoryAndReturnBody(churchId, "Hidden", "INCOME"))
+
+        mockMvc
+            .perform(
+                patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchId, toDeactivateId)
+                    .param("version", "0"),
+            ).andExpect(status().isOk)
+
+        mockMvc
+            .perform(get("/api/v1/churches/{churchId}/transaction-categories", churchId))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(1))
+            .andExpect(jsonPath("$[0].id").value(activeId))
+
+        mockMvc
+            .perform(
+                get("/api/v1/churches/{churchId}/transaction-categories", churchId)
+                    .param("status", "ALL"),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.length()").value(2))
     }
 }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.springframework.boot.testcontainers.context.ImportTestcontainers
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -34,6 +35,20 @@ class TransactionCategoryIntegrationTest {
             .contentType(MediaType.APPLICATION_JSON)
             .content("""{"name": "$name", "type": "$type"}"""),
     )
+
+    private fun createCategoryAndReturnBody(
+        churchId: UUID,
+        name: String = "Offerings",
+        type: String = "INCOME",
+    ): String =
+        mockMvc.perform(
+            post("/api/v1/churches/{churchId}/transaction-categories", churchId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"name": "$name", "type": "$type"}"""),
+        ).andExpect(status().isCreated)
+            .andReturn().response.contentAsString
+
+    private fun extractId(body: String): String = objectMapper.readTree(body).get("id").asString()
 
     private fun createChurch(name: String = "Our Saviour Lutheran Church"): String {
         val result =

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
@@ -11,6 +11,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import tools.jackson.databind.ObjectMapper
@@ -194,6 +195,97 @@ class TransactionCategoryIntegrationTest {
             ).andExpect(status().isOk)
             .andExpect(jsonPath("$.length()").value(1))
             .andExpect(jsonPath("$[0].name").value("Tithes"))
+    }
+
+    @Test
+    fun `PUT updates name and returns 200`() {
+        val churchId = UUID.fromString(createChurch())
+        val id = extractId(createCategoryAndReturnBody(churchId, "Old", "INCOME"))
+
+        mockMvc
+            .perform(
+                put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "New", "version": 0}"""),
+            ).andExpect(status().isOk)
+            .andExpect(jsonPath("$.name").value("New"))
+    }
+
+    @Test
+    fun `PUT returns 400 on blank name`() {
+        val churchId = UUID.fromString(createChurch())
+        val id = extractId(createCategoryAndReturnBody(churchId, "Old", "INCOME"))
+
+        mockMvc
+            .perform(
+                put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "", "version": 0}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(jsonPath("$.message").exists())
+    }
+
+    @Test
+    fun `PUT returns 404 on unknown id`() {
+        val churchId = UUID.fromString(createChurch())
+        val unknownId = UUID.randomUUID()
+
+        mockMvc
+            .perform(
+                put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, unknownId)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Anything", "version": 0}"""),
+            ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `PUT returns 404 on tenant mismatch`() {
+        val churchOne = UUID.fromString(createChurch("Church One"))
+        val churchTwo = UUID.fromString(createChurch("Church Two"))
+        val id = extractId(createCategoryAndReturnBody(churchOne, "Tithes", "INCOME"))
+
+        mockMvc
+            .perform(
+                put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchTwo, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Renamed", "version": 0}"""),
+            ).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `PUT returns 409 when stale version`() {
+        val churchId = UUID.fromString(createChurch())
+        val id = extractId(createCategoryAndReturnBody(churchId, "Old", "INCOME"))
+
+        mockMvc
+            .perform(
+                put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "First Update", "version": 0}"""),
+            ).andExpect(status().isOk)
+
+        mockMvc
+            .perform(
+                put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Stale Update", "version": 0}"""),
+            ).andExpect(status().isConflict)
+            .andExpect(jsonPath("$.message").value("Someone else has made a change. Please refresh and try again."))
+    }
+
+    @Test
+    fun `PUT returns 409 when new name collides with another category of the same type`() {
+        val churchId = UUID.fromString(createChurch())
+        createCategoryAndReturnBody(churchId, "Taken", "INCOME")
+        val id = extractId(createCategoryAndReturnBody(churchId, "Other", "INCOME"))
+
+        mockMvc
+            .perform(
+                put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"name": "Taken", "version": 0}"""),
+            ).andExpect(status().isConflict)
+            .andExpect(jsonPath("$.message").exists())
     }
 
     @Test

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/domain/ChurchTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/domain/ChurchTest.kt
@@ -8,7 +8,7 @@ import kotlin.test.assertNotNull
 
 class ChurchTest {
     private fun buildChurch(
-        name: String = "Grace Church",
+        name: String = "Our Saviour Lutheran Church",
         status: ChurchStatus = ChurchStatus.ACTIVE,
     ): Church =
         Church(

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/ChurchMembershipPersistenceTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/ChurchMembershipPersistenceTest.kt
@@ -47,7 +47,7 @@ class ChurchMembershipPersistenceTest {
                 id = UlidCreator.getUlid().toUuid(),
                 createdAt = now,
                 addedBy = UlidCreator.getUlid().toUuid(),
-                name = "Grace Church",
+                name = "Our Saviour Lutheran Church",
                 status = ChurchStatus.ACTIVE,
             )
         churchRepository.save(church)

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/ChurchPersistenceTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/ChurchPersistenceTest.kt
@@ -34,7 +34,7 @@ class ChurchPersistenceTest {
                 id = UlidCreator.getUlid(),
                 createdAt = Instant.now().truncatedTo(ChronoUnit.MICROS),
                 addedBy = UlidCreator.getUlid(),
-                name = "Grace Church",
+                name = "Our Saviour Lutheran Church",
                 status = ChurchStatus.ACTIVE,
             )
 

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
@@ -41,7 +41,7 @@ class TransactionCategoryPersistenceTest {
                 id = UlidCreator.getUlid().toUuid(),
                 createdAt = now,
                 addedBy = UlidCreator.getUlid().toUuid(),
-                name = "Grace Church",
+                name = "Our Saviour Lutheran Church",
                 status = ChurchStatus.ACTIVE,
             )
         churchRepository.save(church)

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
@@ -11,10 +11,13 @@ import jakarta.transaction.Transactional
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.testcontainers.context.ImportTestcontainers
+import org.springframework.dao.DataIntegrityViolationException
 import java.time.Instant
 import java.time.temporal.ChronoUnit
+import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 @SpringBootTest
 @ImportTestcontainers(TestcontainersConfiguration::class)
@@ -66,4 +69,76 @@ class TransactionCategoryPersistenceTest {
 
         assertEquals(category, retrievedCategory)
     }
+
+    @Test
+    fun `unique constraint allows same name with different transaction_type`() {
+        val churchId = persistChurch()
+        val income = buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.INCOME)
+        val expense = buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.EXPENDITURE)
+
+        transactionCategoryRepository.saveAndFlush(income)
+        transactionCategoryRepository.saveAndFlush(expense)
+
+        val all = transactionCategoryRepository.findAll().filter { it.churchId == churchId }
+        assertEquals(2, all.size)
+    }
+
+    @Test
+    fun `unique constraint allows same name in different churches`() {
+        val churchOne = persistChurch(name = "Church One")
+        val churchTwo = persistChurch(name = "Church Two")
+        transactionCategoryRepository.saveAndFlush(
+            buildJpaEntity(churchId = churchOne, name = "Tithes", type = FinancialTransactionType.INCOME),
+        )
+        transactionCategoryRepository.saveAndFlush(
+            buildJpaEntity(churchId = churchTwo, name = "Tithes", type = FinancialTransactionType.INCOME),
+        )
+
+        val all =
+            transactionCategoryRepository
+                .findAll()
+                .filter { it.churchId == churchOne || it.churchId == churchTwo }
+        assertEquals(2, all.count { it.name == "Tithes" })
+    }
+
+    @Test
+    fun `unique constraint rejects duplicate church_id, name, transaction_type`() {
+        val churchId = persistChurch()
+        transactionCategoryRepository.saveAndFlush(
+            buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.INCOME),
+        )
+
+        assertFailsWith<DataIntegrityViolationException> {
+            transactionCategoryRepository.saveAndFlush(
+                buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.INCOME),
+            )
+        }
+    }
+
+    private fun persistChurch(name: String = "Test Church"): UUID {
+        val church =
+            ChurchJpaEntity(
+                id = UUID.randomUUID(),
+                createdAt = Instant.now(),
+                addedBy = UUID.randomUUID(),
+                name = name,
+                status = ChurchStatus.ACTIVE,
+            )
+        churchRepository.saveAndFlush(church)
+        return church.id
+    }
+
+    private fun buildJpaEntity(
+        churchId: UUID,
+        name: String,
+        type: FinancialTransactionType,
+    ): TransactionCategoryJpaEntity =
+        TransactionCategoryJpaEntity(
+            id = UUID.randomUUID(),
+            churchId = churchId,
+            createdAt = Instant.now(),
+            addedBy = UUID.randomUUID(),
+            name = name,
+            transactionType = type,
+        )
 }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
@@ -19,6 +19,9 @@ import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 @SpringBootTest
 @ImportTestcontainers(TestcontainersConfiguration::class)
@@ -132,6 +135,60 @@ class TransactionCategoryPersistenceTest {
                 buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.INCOME),
             )
         }
+    }
+
+    @Test
+    fun `findByChurchIdAndNameAndTransactionType returns matching category`() {
+        val churchId = persistChurch()
+        val entity = buildJpaEntity(churchId = churchId, name = "Offerings", type = FinancialTransactionType.INCOME)
+        transactionCategoryRepository.saveAndFlush(entity)
+
+        val found =
+            transactionCategoryRepository.findByChurchIdAndNameAndTransactionType(
+                churchId = churchId,
+                name = "Offerings",
+                transactionType = FinancialTransactionType.INCOME,
+            )
+
+        assertNotNull(found)
+        assertEquals(entity.id, found.id)
+    }
+
+    @Test
+    fun `findByChurchIdAndNameAndTransactionType returns null when type differs`() {
+        val churchId = persistChurch()
+        transactionCategoryRepository.saveAndFlush(
+            buildJpaEntity(churchId = churchId, name = "Offerings", type = FinancialTransactionType.INCOME),
+        )
+
+        val found =
+            transactionCategoryRepository.findByChurchIdAndNameAndTransactionType(
+                churchId = churchId,
+                name = "Offerings",
+                transactionType = FinancialTransactionType.EXPENDITURE,
+            )
+
+        assertNull(found)
+    }
+
+    @Test
+    fun `findAllByChurchId returns only categories for that church`() {
+        val churchOne = persistChurch("Church One")
+        val churchTwo = persistChurch("Church Two")
+        transactionCategoryRepository.saveAndFlush(
+            buildJpaEntity(churchId = churchOne, name = "A", type = FinancialTransactionType.INCOME),
+        )
+        transactionCategoryRepository.saveAndFlush(
+            buildJpaEntity(churchId = churchOne, name = "B", type = FinancialTransactionType.EXPENDITURE),
+        )
+        transactionCategoryRepository.saveAndFlush(
+            buildJpaEntity(churchId = churchTwo, name = "C", type = FinancialTransactionType.INCOME),
+        )
+
+        val results = transactionCategoryRepository.findAllByChurchId(churchOne)
+
+        assertEquals(2, results.size)
+        assertTrue(results.all { it.churchId == churchOne })
     }
 
     private fun persistChurch(name: String = "Test Church"): UUID {

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
@@ -3,6 +3,7 @@ package com.calvintech.churchfinance.administration.persistence
 import com.calvintech.churchfinance.TestcontainersConfiguration
 import com.calvintech.churchfinance.administration.domain.ChurchStatus
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
 import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
 import com.github.f4b6a3.ulid.Ulid
 import com.github.f4b6a3.ulid.UlidCreator
@@ -68,6 +69,24 @@ class TransactionCategoryPersistenceTest {
         val retrievedCategory = transactionCategoryMapper.toDomain(retrievedEntity)
 
         assertEquals(category, retrievedCategory)
+        assertEquals(TransactionCategoryStatus.ACTIVE, retrievedCategory.status)
+    }
+
+    @Test
+    fun `status field round-trips through JPA`() {
+        val churchId = persistChurch()
+        val entity =
+            buildJpaEntity(churchId = churchId, name = "Offerings", type = FinancialTransactionType.INCOME)
+                .also { it.status = TransactionCategoryStatus.ACTIVE }
+
+        transactionCategoryRepository.saveAndFlush(entity)
+        val loaded = transactionCategoryRepository.findById(entity.id).orElseThrow()
+        assertEquals(TransactionCategoryStatus.ACTIVE, loaded.status)
+
+        loaded.status = TransactionCategoryStatus.INACTIVE
+        transactionCategoryRepository.saveAndFlush(loaded)
+        val reloaded = transactionCategoryRepository.findById(entity.id).orElseThrow()
+        assertEquals(TransactionCategoryStatus.INACTIVE, reloaded.status)
     }
 
     @Test

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/ChurchServiceTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/ChurchServiceTest.kt
@@ -42,7 +42,7 @@ class ChurchServiceTest {
     }
 
     private fun buildChurch(
-        name: String = "Grace Church",
+        name: String = "Our Saviour Lutheran Church",
         status: ChurchStatus = ChurchStatus.ACTIVE,
         version: Long = 0L,
     ): Church =
@@ -57,7 +57,7 @@ class ChurchServiceTest {
 
     private fun buildChurchJpaEntity(
         id: UUID = UUID.randomUUID(),
-        name: String = "Grace Church",
+        name: String = "Our Saviour Lutheran Church",
         status: ChurchStatus = ChurchStatus.ACTIVE,
         version: Long = 0L,
     ): ChurchJpaEntity =
@@ -74,17 +74,17 @@ class ChurchServiceTest {
     fun `create should persist and return a new church`() {
         val currentUserId = UlidCreator.getUlid()
         val churchSlot = slot<Church>()
-        val savedEntity = buildChurchJpaEntity(name = "Grace Church")
-        val savedChurch = buildChurch(name = "Grace Church")
+        val savedEntity = buildChurchJpaEntity(name = "Our Saviour Lutheran Church")
+        val savedChurch = buildChurch(name = "Our Saviour Lutheran Church")
 
         every { userProvider.getCurrentUserId() } returns currentUserId
         every { churchMapper.toJpaEntity(capture(churchSlot)) } returns savedEntity
         every { churchRepository.save(savedEntity) } returns savedEntity
         every { churchMapper.toDomain(savedEntity) } returns savedChurch
 
-        val response = churchService.create(CreateChurchRequest(name = "Grace Church"))
+        val response = churchService.create(CreateChurchRequest(name = "Our Saviour Lutheran Church"))
 
-        assertEquals("Grace Church", response.name)
+        assertEquals("Our Saviour Lutheran Church", response.name)
         assertEquals(ChurchStatus.ACTIVE, response.status)
         assertNotNull(response.id)
         assertEquals(currentUserId, churchSlot.captured.addedBy)
@@ -92,8 +92,8 @@ class ChurchServiceTest {
 
     @Test
     fun `get should return an existing church`() {
-        val church = buildChurch(name = "Grace Church")
-        val jpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "Grace Church")
+        val church = buildChurch(name = "Our Saviour Lutheran Church")
+        val jpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "Our Saviour Lutheran Church")
 
         every { churchRepository.findById(church.id.toUuid()) } returns Optional.of(jpaEntity)
         every { churchMapper.toDomain(jpaEntity) } returns church
@@ -101,7 +101,7 @@ class ChurchServiceTest {
         val response = churchService.get(church.id.toUuid())
 
         assertEquals(church.id.toUuid(), response.id)
-        assertEquals("Grace Church", response.name)
+        assertEquals("Our Saviour Lutheran Church", response.name)
         assertEquals(ChurchStatus.ACTIVE, response.status)
     }
 
@@ -118,8 +118,8 @@ class ChurchServiceTest {
 
     @Test
     fun `update should change the church name`() {
-        val church = buildChurch(name = "Grace Church", version = 1L)
-        val jpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "Grace Church", version = 1L)
+        val church = buildChurch(name = "Our Saviour Lutheran Church", version = 1L)
+        val jpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "Our Saviour Lutheran Church", version = 1L)
         val updatedChurch = church.copy(name = "New Life Church", version = 1L)
         val updatedJpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "New Life Church", version = 1L)
 
@@ -152,10 +152,11 @@ class ChurchServiceTest {
 
     @Test
     fun `deactivate should set status to INACTIVE`() {
-        val church = buildChurch(name = "Grace Church")
-        val jpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "Grace Church")
+        val church = buildChurch(name = "Our Saviour Lutheran Church")
+        val jpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "Our Saviour Lutheran Church")
         val deactivatedChurch = church.copy(status = ChurchStatus.INACTIVE)
-        val deactivatedJpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "Grace Church", status = ChurchStatus.INACTIVE)
+        val deactivatedJpaEntity =
+            buildChurchJpaEntity(id = church.id.toUuid(), name = "Our Saviour Lutheran Church", status = ChurchStatus.INACTIVE)
 
         every { churchRepository.findById(church.id.toUuid()) } returns Optional.of(jpaEntity)
         every { churchMapper.toDomain(jpaEntity) } returns church
@@ -182,10 +183,11 @@ class ChurchServiceTest {
 
     @Test
     fun `activate should set status to ACTIVE`() {
-        val church = buildChurch(name = "Grace Church", status = ChurchStatus.INACTIVE)
-        val jpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "Grace Church", status = ChurchStatus.INACTIVE)
+        val church = buildChurch(name = "Our Saviour Lutheran Church", status = ChurchStatus.INACTIVE)
+        val jpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "Our Saviour Lutheran Church", status = ChurchStatus.INACTIVE)
         val activatedChurch = church.copy(status = ChurchStatus.ACTIVE)
-        val activatedJpaEntity = buildChurchJpaEntity(id = church.id.toUuid(), name = "Grace Church", status = ChurchStatus.ACTIVE)
+        val activatedJpaEntity =
+            buildChurchJpaEntity(id = church.id.toUuid(), name = "Our Saviour Lutheran Church", status = ChurchStatus.ACTIVE)
 
         every { churchRepository.findById(church.id.toUuid()) } returns Optional.of(jpaEntity)
         every { churchMapper.toDomain(jpaEntity) } returns church

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
@@ -1,0 +1,95 @@
+package com.calvintech.churchfinance.administration.service
+
+import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
+import com.calvintech.churchfinance.administration.domain.TransactionCategory
+import com.calvintech.churchfinance.administration.persistence.TransactionCategoryJpaEntity
+import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
+import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import com.calvintech.churchfinance.shared.service.CurrentUserProvider
+import com.github.f4b6a3.ulid.UlidCreator
+import io.mockk.MockKAnnotations
+import io.mockk.every
+import io.mockk.impl.annotations.MockK
+import io.mockk.slot
+import org.junit.jupiter.api.Assertions.assertNotNull
+import java.time.Instant
+import java.util.UUID
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TransactionCategoryTest {
+    @MockK
+    lateinit var repository: TransactionCategoryRepository
+
+    @MockK
+    lateinit var mapper: TransactionCategoryMapper
+
+    @MockK
+    lateinit var userProvider: CurrentUserProvider
+
+    lateinit var transactionCategoryService: TransactionCategoryService
+
+    @BeforeTest
+    fun setUp() {
+        MockKAnnotations.init(this)
+        transactionCategoryService = TransactionCategoryService(mapper, repository, userProvider)
+    }
+
+    private fun buildTransactionCategory(
+        name: String,
+        transactionType: FinancialTransactionType,
+        version: Long = 0L,
+    ): TransactionCategory =
+        TransactionCategory(
+            id = UlidCreator.getUlid(),
+            churchId = UlidCreator.getUlid(),
+            addedBy = UlidCreator.getUlid(),
+            createdAt = Instant.now(),
+            name = name,
+            transactionType = transactionType,
+            version = version,
+        )
+
+    private fun buildTransactionCategoryJpaEntity(
+        id: UUID = UUID.randomUUID(),
+        name: String,
+        transactionType: FinancialTransactionType,
+        version: Long = 0L,
+    ): TransactionCategoryJpaEntity =
+        TransactionCategoryJpaEntity(
+            id = id,
+            churchId = UUID.randomUUID(),
+            addedBy = UUID.randomUUID(),
+            createdAt = Instant.now(),
+            name = name,
+            transactionType = transactionType,
+            version = version,
+        )
+
+    @Test
+    fun `create should persist and return a new transaction category`() {
+        val churchId = UUID.randomUUID()
+        val currentUserId = UlidCreator.getUlid()
+        val transactionCategorySlot = slot<TransactionCategory>()
+        val savedEntity = buildTransactionCategoryJpaEntity(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+        val savedTransactionCategory = buildTransactionCategory(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+
+        every { userProvider.getCurrentUserId() } returns currentUserId
+        every { mapper.toJpaEntity(capture(transactionCategorySlot)) } returns savedEntity
+        every { repository.save(savedEntity) } returns savedEntity
+        every { mapper.toDomain(savedEntity) } returns savedTransactionCategory
+
+        val response =
+            transactionCategoryService.create(
+                churchId,
+                CreateTransactionCategoryRequest(name = "Offerings", type = FinancialTransactionType.INCOME),
+            )
+
+        assertEquals("Offerings", response.name)
+        assertEquals(FinancialTransactionType.INCOME, response.type)
+        assertNotNull(response.id)
+        assertEquals(currentUserId, transactionCategorySlot.captured.addedBy)
+    }
+}

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
@@ -231,7 +231,7 @@ class TransactionCategoryTest {
             transactionCategoryService.update(
                 churchId = churchId,
                 id = id,
-                req = UpdateTransactionCategoryRequest(name = "New", version = 0),
+                updateTransactionCategoryRequest = UpdateTransactionCategoryRequest(name = "New", version = 0),
             )
 
         assertEquals("New", response.name)
@@ -257,7 +257,7 @@ class TransactionCategoryTest {
         transactionCategoryService.update(
             churchId = churchId,
             id = id,
-            req = UpdateTransactionCategoryRequest(name = "Same", version = 0),
+            updateTransactionCategoryRequest = UpdateTransactionCategoryRequest(name = "Same", version = 0),
         )
 
         verify(exactly = 0) {
@@ -290,37 +290,9 @@ class TransactionCategoryTest {
             transactionCategoryService.update(
                 churchId = churchId,
                 id = id,
-                req = UpdateTransactionCategoryRequest(name = "Taken", version = 0),
+                updateTransactionCategoryRequest = UpdateTransactionCategoryRequest(name = "Taken", version = 0),
             )
         }
-    }
-
-    @Test
-    fun `update permits keeping the same name (excludingId guard)`() {
-        val churchId = UUID.randomUUID()
-        val id = UUID.randomUUID()
-        val existing =
-            buildTransactionCategoryJpaEntity(id = id, name = "Old", transactionType = FinancialTransactionType.INCOME)
-                .also { it.churchId = churchId }
-        val existingDomain =
-            buildTransactionCategory(name = "Old", transactionType = FinancialTransactionType.INCOME)
-                .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
-
-        every { repository.findById(id) } returns java.util.Optional.of(existing)
-        every { mapper.toDomain(existing) } returns existingDomain
-        // findBy is NOT called because name is unchanged; covered by the "skips uniqueness check" test.
-        every { mapper.toJpaEntity(any()) } returns existing
-        every { repository.save(existing) } returns existing
-        every { mapper.toDomain(existing) } returns existingDomain
-
-        val response =
-            transactionCategoryService.update(
-                churchId = churchId,
-                id = id,
-                req = UpdateTransactionCategoryRequest(name = "Old", version = 0),
-            )
-
-        assertEquals("Old", response.name)
     }
 
     @Test
@@ -342,7 +314,7 @@ class TransactionCategoryTest {
             transactionCategoryService.update(
                 churchId = urlChurchId,
                 id = id,
-                req = UpdateTransactionCategoryRequest(name = "Y", version = 0),
+                updateTransactionCategoryRequest = UpdateTransactionCategoryRequest(name = "Y", version = 0),
             )
         }
     }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
@@ -4,7 +4,9 @@ import com.calvintech.churchfinance.administration.api.CreateTransactionCategory
 import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
+import com.github.f4b6a3.ulid.Ulid
 import com.calvintech.churchfinance.administration.persistence.ChurchRepository
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryJpaEntity
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
@@ -142,6 +144,54 @@ class TransactionCategoryTest {
                 churchId,
                 CreateTransactionCategoryRequest(name = "Offerings", type = FinancialTransactionType.INCOME),
             )
+        }
+    }
+
+    @Test
+    fun `get returns category when it belongs to the church`() {
+        val churchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val entity =
+            buildTransactionCategoryJpaEntity(id = id, name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = churchId }
+        val domain = buildTransactionCategory(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+
+        every { repository.findById(id) } returns java.util.Optional.of(entity)
+        every { mapper.toDomain(entity) } returns domain.copy(churchId = Ulid.from(churchId))
+
+        val response = transactionCategoryService.get(churchId, id)
+
+        assertEquals("Offerings", response.name)
+    }
+
+    @Test
+    fun `get throws TransactionCategoryNotFoundException when id unknown`() {
+        val churchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        every { repository.findById(id) } returns java.util.Optional.empty()
+
+        assertFailsWith<TransactionCategoryNotFoundException> {
+            transactionCategoryService.get(churchId, id)
+        }
+    }
+
+    @Test
+    fun `get throws TransactionCategoryNotFoundException when category belongs to a different church`() {
+        val urlChurchId = UUID.randomUUID()
+        val actualChurchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val entity =
+            buildTransactionCategoryJpaEntity(id = id, name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = actualChurchId }
+        val domain =
+            buildTransactionCategory(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+                .copy(churchId = Ulid.from(actualChurchId))
+
+        every { repository.findById(id) } returns java.util.Optional.of(entity)
+        every { mapper.toDomain(entity) } returns domain
+
+        assertFailsWith<TransactionCategoryNotFoundException> {
+            transactionCategoryService.get(urlChurchId, id)
         }
     }
 }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
@@ -2,6 +2,7 @@ package com.calvintech.churchfinance.administration.service
 
 import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryJpaEntity
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
@@ -89,6 +90,7 @@ class TransactionCategoryTest {
 
         assertEquals("Offerings", response.name)
         assertEquals(FinancialTransactionType.INCOME, response.type)
+        assertEquals(TransactionCategoryStatus.ACTIVE, response.status)
         assertNotNull(response.id)
         assertEquals(currentUserId, transactionCategorySlot.captured.addedBy)
     }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
@@ -3,6 +3,7 @@ package com.calvintech.churchfinance.administration.service
 import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
 import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
 import com.calvintech.churchfinance.administration.persistence.ChurchRepository
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryJpaEntity
@@ -84,6 +85,13 @@ class TransactionCategoryTest {
         val savedTransactionCategory = buildTransactionCategory(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
 
         every { churchRepository.existsById(churchId) } returns true
+        every {
+            repository.findByChurchIdAndNameAndTransactionType(
+                churchId = churchId,
+                name = "Offerings",
+                transactionType = FinancialTransactionType.INCOME,
+            )
+        } returns null
         every { userProvider.getCurrentUserId() } returns currentUserId
         every { mapper.toJpaEntity(capture(transactionCategorySlot)) } returns savedEntity
         every { repository.save(savedEntity) } returns savedEntity
@@ -108,6 +116,28 @@ class TransactionCategoryTest {
         every { churchRepository.existsById(churchId) } returns false
 
         assertFailsWith<ChurchNotFoundException> {
+            transactionCategoryService.create(
+                churchId,
+                CreateTransactionCategoryRequest(name = "Offerings", type = FinancialTransactionType.INCOME),
+            )
+        }
+    }
+
+    @Test
+    fun `create throws TransactionCategoryNameConflictException when (church, name, type) already exists`() {
+        val churchId = UUID.randomUUID()
+        val existing = buildTransactionCategoryJpaEntity(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+
+        every { churchRepository.existsById(churchId) } returns true
+        every {
+            repository.findByChurchIdAndNameAndTransactionType(
+                churchId = churchId,
+                name = "Offerings",
+                transactionType = FinancialTransactionType.INCOME,
+            )
+        } returns existing
+
+        assertFailsWith<TransactionCategoryNameConflictException> {
             transactionCategoryService.create(
                 churchId,
                 CreateTransactionCategoryRequest(name = "Offerings", type = FinancialTransactionType.INCOME),

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
@@ -2,6 +2,7 @@ package com.calvintech.churchfinance.administration.service
 
 import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
 import com.calvintech.churchfinance.administration.api.TransactionCategoryStatusFilter
+import com.calvintech.churchfinance.administration.api.UpdateTransactionCategoryRequest
 import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
@@ -19,6 +20,7 @@ import io.mockk.MockKAnnotations
 import io.mockk.every
 import io.mockk.impl.annotations.MockK
 import io.mockk.slot
+import io.mockk.verify
 import org.junit.jupiter.api.Assertions.assertNotNull
 import java.time.Instant
 import java.util.UUID
@@ -193,6 +195,155 @@ class TransactionCategoryTest {
 
         assertFailsWith<TransactionCategoryNotFoundException> {
             transactionCategoryService.get(urlChurchId, id)
+        }
+    }
+
+    @Test
+    fun `update changes name and returns updated response`() {
+        val churchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val existing =
+            buildTransactionCategoryJpaEntity(id = id, name = "Old", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = churchId }
+        val existingDomain =
+            buildTransactionCategory(name = "Old", transactionType = FinancialTransactionType.INCOME)
+                .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
+        val saved =
+            buildTransactionCategoryJpaEntity(id = id, name = "New", transactionType = FinancialTransactionType.INCOME)
+                .also {
+                    it.churchId = churchId
+                    it.version = 1
+                }
+        val savedDomain =
+            buildTransactionCategory(name = "New", transactionType = FinancialTransactionType.INCOME)
+                .copy(id = Ulid.from(id), churchId = Ulid.from(churchId), version = 1)
+
+        every { repository.findById(id) } returns java.util.Optional.of(existing)
+        every { mapper.toDomain(existing) } returns existingDomain
+        every {
+            repository.findByChurchIdAndNameAndTransactionType(churchId, "New", FinancialTransactionType.INCOME)
+        } returns null
+        every { mapper.toJpaEntity(any()) } returns saved
+        every { repository.save(saved) } returns saved
+        every { mapper.toDomain(saved) } returns savedDomain
+
+        val response =
+            transactionCategoryService.update(
+                churchId = churchId,
+                id = id,
+                req = UpdateTransactionCategoryRequest(name = "New", version = 0),
+            )
+
+        assertEquals("New", response.name)
+    }
+
+    @Test
+    fun `update skips uniqueness check when name is unchanged`() {
+        val churchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val existing =
+            buildTransactionCategoryJpaEntity(id = id, name = "Same", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = churchId }
+        val existingDomain =
+            buildTransactionCategory(name = "Same", transactionType = FinancialTransactionType.INCOME)
+                .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
+
+        every { repository.findById(id) } returns java.util.Optional.of(existing)
+        every { mapper.toDomain(existing) } returns existingDomain
+        every { mapper.toJpaEntity(any()) } returns existing
+        every { repository.save(existing) } returns existing
+        every { mapper.toDomain(existing) } returns existingDomain
+
+        transactionCategoryService.update(
+            churchId = churchId,
+            id = id,
+            req = UpdateTransactionCategoryRequest(name = "Same", version = 0),
+        )
+
+        verify(exactly = 0) {
+            repository.findByChurchIdAndNameAndTransactionType(any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `update throws conflict when new name collides with another category of the same type`() {
+        val churchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val collidingId = UUID.randomUUID()
+        val existing =
+            buildTransactionCategoryJpaEntity(id = id, name = "Old", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = churchId }
+        val existingDomain =
+            buildTransactionCategory(name = "Old", transactionType = FinancialTransactionType.INCOME)
+                .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
+        val colliding =
+            buildTransactionCategoryJpaEntity(id = collidingId, name = "Taken", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = churchId }
+
+        every { repository.findById(id) } returns java.util.Optional.of(existing)
+        every { mapper.toDomain(existing) } returns existingDomain
+        every {
+            repository.findByChurchIdAndNameAndTransactionType(churchId, "Taken", FinancialTransactionType.INCOME)
+        } returns colliding
+
+        assertFailsWith<TransactionCategoryNameConflictException> {
+            transactionCategoryService.update(
+                churchId = churchId,
+                id = id,
+                req = UpdateTransactionCategoryRequest(name = "Taken", version = 0),
+            )
+        }
+    }
+
+    @Test
+    fun `update permits keeping the same name (excludingId guard)`() {
+        val churchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val existing =
+            buildTransactionCategoryJpaEntity(id = id, name = "Old", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = churchId }
+        val existingDomain =
+            buildTransactionCategory(name = "Old", transactionType = FinancialTransactionType.INCOME)
+                .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
+
+        every { repository.findById(id) } returns java.util.Optional.of(existing)
+        every { mapper.toDomain(existing) } returns existingDomain
+        // findBy is NOT called because name is unchanged; covered by the "skips uniqueness check" test.
+        every { mapper.toJpaEntity(any()) } returns existing
+        every { repository.save(existing) } returns existing
+        every { mapper.toDomain(existing) } returns existingDomain
+
+        val response =
+            transactionCategoryService.update(
+                churchId = churchId,
+                id = id,
+                req = UpdateTransactionCategoryRequest(name = "Old", version = 0),
+            )
+
+        assertEquals("Old", response.name)
+    }
+
+    @Test
+    fun `update throws not-found on tenant mismatch`() {
+        val urlChurchId = UUID.randomUUID()
+        val actualChurchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val existing =
+            buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = actualChurchId }
+        val existingDomain =
+            buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+                .copy(id = Ulid.from(id), churchId = Ulid.from(actualChurchId))
+
+        every { repository.findById(id) } returns java.util.Optional.of(existing)
+        every { mapper.toDomain(existing) } returns existingDomain
+
+        assertFailsWith<TransactionCategoryNotFoundException> {
+            transactionCategoryService.update(
+                churchId = urlChurchId,
+                id = id,
+                req = UpdateTransactionCategoryRequest(name = "Y", version = 0),
+            )
         }
     }
 

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
@@ -6,13 +6,13 @@ import com.calvintech.churchfinance.administration.domain.TransactionCategory
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
-import com.github.f4b6a3.ulid.Ulid
 import com.calvintech.churchfinance.administration.persistence.ChurchRepository
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryJpaEntity
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
 import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
 import com.calvintech.churchfinance.shared.service.CurrentUserProvider
+import com.github.f4b6a3.ulid.Ulid
 import com.github.f4b6a3.ulid.UlidCreator
 import io.mockk.MockKAnnotations
 import io.mockk.every

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
@@ -1,6 +1,7 @@
 package com.calvintech.churchfinance.administration.service
 
 import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
+import com.calvintech.churchfinance.administration.api.TransactionCategoryStatusFilter
 import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
@@ -192,6 +193,104 @@ class TransactionCategoryTest {
 
         assertFailsWith<TransactionCategoryNotFoundException> {
             transactionCategoryService.get(urlChurchId, id)
+        }
+    }
+
+    private fun jpaList(vararg entities: TransactionCategoryJpaEntity) = entities.toList()
+
+    @Test
+    fun `list returns only ACTIVE categories sorted by name when no filters supplied`() {
+        val churchId = UUID.randomUUID()
+        val active = buildTransactionCategoryJpaEntity(name = "Tithes", transactionType = FinancialTransactionType.INCOME)
+        val inactive =
+            buildTransactionCategoryJpaEntity(name = "Old", transactionType = FinancialTransactionType.INCOME)
+                .also { it.status = TransactionCategoryStatus.INACTIVE }
+
+        every { churchRepository.existsById(churchId) } returns true
+        every { repository.findAllByChurchId(churchId) } returns jpaList(inactive, active)
+        every { mapper.toDomain(active) } returns
+            buildTransactionCategory(name = "Tithes", transactionType = FinancialTransactionType.INCOME)
+        every { mapper.toDomain(inactive) } returns
+            buildTransactionCategory(
+                name = "Old",
+                transactionType = FinancialTransactionType.INCOME,
+            ).copy(status = TransactionCategoryStatus.INACTIVE)
+
+        val result = transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.ACTIVE, type = null)
+
+        assertEquals(1, result.size)
+        assertEquals("Tithes", result.first().name)
+    }
+
+    @Test
+    fun `list with status=ALL returns all rows sorted by name`() {
+        val churchId = UUID.randomUUID()
+        val a = buildTransactionCategoryJpaEntity(name = "Z", transactionType = FinancialTransactionType.INCOME)
+        val b =
+            buildTransactionCategoryJpaEntity(name = "A", transactionType = FinancialTransactionType.EXPENDITURE)
+                .also { it.status = TransactionCategoryStatus.INACTIVE }
+
+        every { churchRepository.existsById(churchId) } returns true
+        every { repository.findAllByChurchId(churchId) } returns jpaList(a, b)
+        every { mapper.toDomain(a) } returns buildTransactionCategory(name = "Z", transactionType = FinancialTransactionType.INCOME)
+        every { mapper.toDomain(b) } returns
+            buildTransactionCategory(name = "A", transactionType = FinancialTransactionType.EXPENDITURE)
+                .copy(status = TransactionCategoryStatus.INACTIVE)
+
+        val result = transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.ALL, type = null)
+
+        assertEquals(listOf("A", "Z"), result.map { it.name })
+    }
+
+    @Test
+    fun `list with status=INACTIVE returns only inactive`() {
+        val churchId = UUID.randomUUID()
+        val active = buildTransactionCategoryJpaEntity(name = "X", transactionType = FinancialTransactionType.INCOME)
+        val inactive =
+            buildTransactionCategoryJpaEntity(name = "Y", transactionType = FinancialTransactionType.INCOME)
+                .also { it.status = TransactionCategoryStatus.INACTIVE }
+
+        every { churchRepository.existsById(churchId) } returns true
+        every { repository.findAllByChurchId(churchId) } returns jpaList(active, inactive)
+        every { mapper.toDomain(active) } returns buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+        every { mapper.toDomain(inactive) } returns
+            buildTransactionCategory(name = "Y", transactionType = FinancialTransactionType.INCOME)
+                .copy(status = TransactionCategoryStatus.INACTIVE)
+
+        val result = transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.INACTIVE, type = null)
+
+        assertEquals(listOf("Y"), result.map { it.name })
+    }
+
+    @Test
+    fun `list with type filter returns only matching type`() {
+        val churchId = UUID.randomUUID()
+        val income = buildTransactionCategoryJpaEntity(name = "X", transactionType = FinancialTransactionType.INCOME)
+        val expense = buildTransactionCategoryJpaEntity(name = "Y", transactionType = FinancialTransactionType.EXPENDITURE)
+
+        every { churchRepository.existsById(churchId) } returns true
+        every { repository.findAllByChurchId(churchId) } returns jpaList(income, expense)
+        every { mapper.toDomain(income) } returns buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+        every { mapper.toDomain(expense) } returns
+            buildTransactionCategory(name = "Y", transactionType = FinancialTransactionType.EXPENDITURE)
+
+        val result =
+            transactionCategoryService.list(
+                churchId,
+                TransactionCategoryStatusFilter.ACTIVE,
+                type = FinancialTransactionType.INCOME,
+            )
+
+        assertEquals(listOf("X"), result.map { it.name })
+    }
+
+    @Test
+    fun `list throws ChurchNotFoundException when church does not exist`() {
+        val churchId = UUID.randomUUID()
+        every { churchRepository.existsById(churchId) } returns false
+
+        assertFailsWith<ChurchNotFoundException> {
+            transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.ACTIVE, type = null)
         }
     }
 }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
@@ -1,8 +1,10 @@
 package com.calvintech.churchfinance.administration.service
 
 import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
+import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
 import com.calvintech.churchfinance.administration.domain.TransactionCategory
 import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
+import com.calvintech.churchfinance.administration.persistence.ChurchRepository
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryJpaEntity
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
 import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
@@ -19,6 +21,7 @@ import java.util.UUID
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class TransactionCategoryTest {
     @MockK
@@ -30,12 +33,15 @@ class TransactionCategoryTest {
     @MockK
     lateinit var userProvider: CurrentUserProvider
 
+    @MockK
+    lateinit var churchRepository: ChurchRepository
+
     lateinit var transactionCategoryService: TransactionCategoryService
 
     @BeforeTest
     fun setUp() {
         MockKAnnotations.init(this)
-        transactionCategoryService = TransactionCategoryService(mapper, repository, userProvider)
+        transactionCategoryService = TransactionCategoryService(mapper, repository, userProvider, churchRepository)
     }
 
     private fun buildTransactionCategory(
@@ -77,6 +83,7 @@ class TransactionCategoryTest {
         val savedEntity = buildTransactionCategoryJpaEntity(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
         val savedTransactionCategory = buildTransactionCategory(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
 
+        every { churchRepository.existsById(churchId) } returns true
         every { userProvider.getCurrentUserId() } returns currentUserId
         every { mapper.toJpaEntity(capture(transactionCategorySlot)) } returns savedEntity
         every { repository.save(savedEntity) } returns savedEntity
@@ -93,5 +100,18 @@ class TransactionCategoryTest {
         assertEquals(TransactionCategoryStatus.ACTIVE, response.status)
         assertNotNull(response.id)
         assertEquals(currentUserId, transactionCategorySlot.captured.addedBy)
+    }
+
+    @Test
+    fun `create throws ChurchNotFoundException when church does not exist`() {
+        val churchId = UUID.randomUUID()
+        every { churchRepository.existsById(churchId) } returns false
+
+        assertFailsWith<ChurchNotFoundException> {
+            transactionCategoryService.create(
+                churchId,
+                CreateTransactionCategoryRequest(name = "Offerings", type = FinancialTransactionType.INCOME),
+            )
+        }
     }
 }

--- a/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+++ b/church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
@@ -444,4 +444,106 @@ class TransactionCategoryTest {
             transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.ACTIVE, type = null)
         }
     }
+
+    @Test
+    fun `deactivate sets status to INACTIVE`() {
+        val churchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val existing =
+            buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = churchId }
+        val existingDomain =
+            buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+                .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
+        val deactivated =
+            buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+                .also {
+                    it.churchId = churchId
+                    it.status = TransactionCategoryStatus.INACTIVE
+                    it.version = 1
+                }
+        val deactivatedDomain = existingDomain.copy(status = TransactionCategoryStatus.INACTIVE, version = 1)
+
+        every { repository.findById(id) } returns java.util.Optional.of(existing)
+        every { mapper.toDomain(existing) } returns existingDomain
+        every { mapper.toJpaEntity(any()) } returns deactivated
+        every { repository.save(deactivated) } returns deactivated
+        every { mapper.toDomain(deactivated) } returns deactivatedDomain
+
+        val response = transactionCategoryService.deactivate(churchId, id, version = 0)
+
+        assertEquals(TransactionCategoryStatus.INACTIVE, response.status)
+    }
+
+    @Test
+    fun `activate sets status to ACTIVE`() {
+        val churchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val existing =
+            buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+                .also {
+                    it.churchId = churchId
+                    it.status = TransactionCategoryStatus.INACTIVE
+                }
+        val existingDomain =
+            buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+                .copy(id = Ulid.from(id), churchId = Ulid.from(churchId), status = TransactionCategoryStatus.INACTIVE)
+        val activated =
+            buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+                .also {
+                    it.churchId = churchId
+                    it.version = 2
+                }
+        val activatedDomain = existingDomain.copy(status = TransactionCategoryStatus.ACTIVE, version = 2)
+
+        every { repository.findById(id) } returns java.util.Optional.of(existing)
+        every { mapper.toDomain(existing) } returns existingDomain
+        every { mapper.toJpaEntity(any()) } returns activated
+        every { repository.save(activated) } returns activated
+        every { mapper.toDomain(activated) } returns activatedDomain
+
+        val response = transactionCategoryService.activate(churchId, id, version = 1)
+
+        assertEquals(TransactionCategoryStatus.ACTIVE, response.status)
+    }
+
+    @Test
+    fun `deactivate throws not-found on tenant mismatch`() {
+        val urlChurchId = UUID.randomUUID()
+        val actualChurchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val existing =
+            buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = actualChurchId }
+        val existingDomain =
+            buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+                .copy(id = Ulid.from(id), churchId = Ulid.from(actualChurchId))
+
+        every { repository.findById(id) } returns java.util.Optional.of(existing)
+        every { mapper.toDomain(existing) } returns existingDomain
+
+        assertFailsWith<TransactionCategoryNotFoundException> {
+            transactionCategoryService.deactivate(urlChurchId, id, version = 0)
+        }
+    }
+
+    @Test
+    fun `activate throws not-found on tenant mismatch`() {
+        val urlChurchId = UUID.randomUUID()
+        val actualChurchId = UUID.randomUUID()
+        val id = UUID.randomUUID()
+        val existing =
+            buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+                .also { it.churchId = actualChurchId }
+        val existingDomain =
+            buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+                .copy(id = Ulid.from(id), churchId = Ulid.from(actualChurchId))
+
+        every { repository.findById(id) } returns java.util.Optional.of(existing)
+        every { mapper.toDomain(existing) } returns existingDomain
+
+        assertFailsWith<TransactionCategoryNotFoundException> {
+            transactionCategoryService.activate(urlChurchId, id, version = 0)
+        }
+    }
 }

--- a/docs/superpowers/plans/2026-05-25-transaction-category-crud.md
+++ b/docs/superpowers/plans/2026-05-25-transaction-category-crud.md
@@ -1,0 +1,2372 @@
+# TransactionCategory CRUD Completion — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+> **Commits:** Calvin commits to git himself. Every task ends with a "Stage and commit" step showing the exact `git add` + `git commit` commands — these are commands **Calvin runs**, not commands the implementing agent runs. The agent stops at that step and surfaces the suggested message.
+
+**Goal:** Complete the TransactionCategory CRUD surface on `feature/transaction-category-crud` — GET-by-id, list (filterable), PUT (name only), PATCH activate/deactivate — mirroring the existing Church aggregate pattern. Adds a soft-deactivation status field, swaps the unique constraint to be type-scoped, and fixes a 500-vs-404 bug on missing church.
+
+**Architecture:** Backend Kotlin/Spring Boot/JPA following DDD vertical-slice packaging (`administration` aggregate, four sub-packages: `domain`, `persistence`, `service`, `api`). Service-layer pre-emptive validation for uniqueness and church existence; DB constraint as TOCTOU safety net. Tenant-scoped 404 (never leak that an entity exists in a different church). Domain entities use Ulid IDs; persistence layer uses UUIDs; manual mappers translate.
+
+**Tech Stack:** Kotlin 2.3.20, Spring Boot 4.0.5, Java 21, PostgreSQL via Flyway, Spring Data JPA, JUnit 5 + kotlin.test, MockK for service unit tests, Testcontainers (`PostgreSQLContainer`) for persistence + integration tests, SpringDoc OpenAPI.
+
+**Spec:** [`docs/superpowers/specs/2026-05-25-transaction-category-crud-design.md`](../specs/2026-05-25-transaction-category-crud-design.md)
+
+---
+
+## File Structure
+
+**Backend root for all paths below:** `church-finance-backend/`
+
+**New files to create:**
+
+| Path | Responsibility |
+|---|---|
+| `src/main/resources/db/migration/V3__transaction_category_status_and_unique.sql` | Add `status` column; swap unique constraint to `(church_id, name, transaction_type)` |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryStatus.kt` | `ACTIVE` / `INACTIVE` enum |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNotFoundException.kt` | Domain exception, mapped to 404 |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNameConflictException.kt` | Domain exception, mapped to 409 |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/api/UpdateTransactionCategoryRequest.kt` | Request DTO for PUT |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryStatusFilter.kt` | Query-param enum for list endpoint |
+
+**Existing files to modify:**
+
+| Path | Responsibility |
+|---|---|
+| `src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategory.kt` | Add `status` field |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryJpaEntity.kt` | Add `status` column |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryMapper.kt` | Round-trip `status` |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryRepository.kt` | Add two derived-query methods |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryResponse.kt` | Add `status` field |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt` | Add 4 new endpoints (GET-by-id, list, PUT, PATCH activate/deactivate) |
+| `src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt` | Add `ChurchRepository` dep, 3 helpers, 5 new methods |
+| `src/main/kotlin/com/calvintech/churchfinance/shared/api/GlobalExceptionHandler.kt` | Add 3 handlers (NotFound 404, NameConflict 409, DataIntegrityViolation 409) |
+
+**Test files to modify (no new test files needed):**
+
+| Path | Additions |
+|---|---|
+| `src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt` | Status round-trip; 3 constraint tests; 2 repo query tests |
+| `src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt` | ~20 new MockK tests |
+| `src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt` | ~22 new MockMvc tests + helper methods |
+
+---
+
+## Task 1: Flyway V3 migration + persistence tests for new unique constraint
+
+**Files:**
+- Create: `church-finance-backend/src/main/resources/db/migration/V3__transaction_category_status_and_unique.sql`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt`
+
+- [ ] **Step 1: Write failing persistence tests for new constraint behavior**
+
+Open `TransactionCategoryPersistenceTest.kt` and add (alongside the existing test) — leave the existing round-trip test untouched:
+
+```kotlin
+@Test
+fun `unique constraint allows same name with different transaction_type`() {
+    val churchId = persistChurch()
+    val income = buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.INCOME)
+    val expense = buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.EXPENSE)
+
+    transactionCategoryRepository.saveAndFlush(income)
+    transactionCategoryRepository.saveAndFlush(expense)
+
+    val all = transactionCategoryRepository.findAll().filter { it.churchId == churchId }
+    assertEquals(2, all.size)
+}
+
+@Test
+fun `unique constraint allows same name in different churches`() {
+    val churchOne = persistChurch(name = "Church One")
+    val churchTwo = persistChurch(name = "Church Two")
+    transactionCategoryRepository.saveAndFlush(
+        buildJpaEntity(churchId = churchOne, name = "Tithes", type = FinancialTransactionType.INCOME),
+    )
+    transactionCategoryRepository.saveAndFlush(
+        buildJpaEntity(churchId = churchTwo, name = "Tithes", type = FinancialTransactionType.INCOME),
+    )
+
+    val all = transactionCategoryRepository.findAll()
+    assertEquals(2, all.count { it.name == "Tithes" })
+}
+
+@Test
+fun `unique constraint rejects duplicate church_id, name, transaction_type`() {
+    val churchId = persistChurch()
+    transactionCategoryRepository.saveAndFlush(
+        buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.INCOME),
+    )
+
+    assertFailsWith<DataIntegrityViolationException> {
+        transactionCategoryRepository.saveAndFlush(
+            buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.INCOME),
+        )
+    }
+}
+```
+
+You will need (add to imports + helpers in the test file — see Step 2):
+
+```kotlin
+import org.springframework.dao.DataIntegrityViolationException
+import kotlin.test.assertFailsWith
+import kotlin.test.assertEquals
+```
+
+- [ ] **Step 2: Ensure test helpers exist in the file**
+
+The existing test file may or may not have `buildJpaEntity` / `persistChurch` helpers. If not, add them as private methods inside the test class:
+
+```kotlin
+private fun persistChurch(name: String = "Test Church"): UUID {
+    val church = ChurchJpaEntity(
+        id = UUID.randomUUID(),
+        createdAt = Instant.now(),
+        addedBy = UUID.randomUUID(),
+        name = name,
+        status = ChurchStatus.ACTIVE,
+    )
+    churchRepository.saveAndFlush(church)
+    return church.id
+}
+
+private fun buildJpaEntity(
+    churchId: UUID,
+    name: String,
+    type: FinancialTransactionType,
+): TransactionCategoryJpaEntity =
+    TransactionCategoryJpaEntity(
+        id = UUID.randomUUID(),
+        churchId = churchId,
+        createdAt = Instant.now(),
+        addedBy = UUID.randomUUID(),
+        name = name,
+        transactionType = type,
+    )
+```
+
+You'll also need `@Autowired lateinit var churchRepository: ChurchRepository` in the test class if it's not already there, plus the obvious imports (`ChurchJpaEntity`, `ChurchStatus`, `ChurchRepository`, `FinancialTransactionType`, `Instant`, `UUID`).
+
+- [ ] **Step 3: Run new tests to confirm they fail**
+
+Run:
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryPersistenceTest*' --rerun-tasks
+```
+
+Expected: the two new "allows" tests fail (DB still rejects same name across different types) OR the "rejects duplicate" test still passes but for the wrong reason (current constraint is `(church_id, name)`). At minimum, `unique constraint allows same name with different transaction_type` should fail with `DataIntegrityViolationException`. That is the regression we are fixing.
+
+- [ ] **Step 4: Create the Flyway migration**
+
+Create `church-finance-backend/src/main/resources/db/migration/V3__transaction_category_status_and_unique.sql`:
+
+```sql
+ALTER TABLE church_finance.transaction_category
+    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE';
+
+ALTER TABLE church_finance.transaction_category
+    DROP CONSTRAINT transaction_category_church_name_unique;
+
+ALTER TABLE church_finance.transaction_category
+    ADD CONSTRAINT transaction_category_church_name_type_unique
+        UNIQUE (church_id, name, transaction_type);
+```
+
+Note: the `status` column is added now so we don't need a fourth migration in Task 2. JPA does not yet map it (Task 2 wires that), but the schema has it with a safe default.
+
+- [ ] **Step 5: Run new tests to confirm they pass**
+
+Run:
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryPersistenceTest*' --rerun-tasks
+```
+
+Expected: all three new tests PASS. The existing round-trip test also PASSES (it doesn't reference `status` yet — Task 2 updates that).
+
+- [ ] **Step 6: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/resources/db/migration/V3__transaction_category_status_and_unique.sql \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
+git commit -m "feat: swap transaction_category unique constraint to (church, name, type)
+
+Add Flyway V3: introduces status column (defaulted ACTIVE) and
+replaces (church_id, name) unique constraint with type-scoped
+variant. Adds persistence tests covering: duplicate rejection,
+same-name-different-type allowance, and cross-church allowance."
+```
+
+---
+
+## Task 2: Add `TransactionCategoryStatus` enum + `status` field through domain, JPA, mapper
+
+**Files:**
+- Create: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryStatus.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategory.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryJpaEntity.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryMapper.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt`
+
+- [ ] **Step 1: Write failing test for status round-trip**
+
+Add to `TransactionCategoryPersistenceTest.kt`:
+
+```kotlin
+@Test
+fun `status field round-trips through JPA`() {
+    val churchId = persistChurch()
+    val entity = buildJpaEntity(churchId = churchId, name = "Offerings", type = FinancialTransactionType.INCOME)
+        .also { it.status = TransactionCategoryStatus.ACTIVE }
+
+    transactionCategoryRepository.saveAndFlush(entity)
+    val loaded = transactionCategoryRepository.findById(entity.id).orElseThrow()
+    assertEquals(TransactionCategoryStatus.ACTIVE, loaded.status)
+
+    loaded.status = TransactionCategoryStatus.INACTIVE
+    transactionCategoryRepository.saveAndFlush(loaded)
+    val reloaded = transactionCategoryRepository.findById(entity.id).orElseThrow()
+    assertEquals(TransactionCategoryStatus.INACTIVE, reloaded.status)
+}
+```
+
+Also update the existing round-trip test (whatever its name is) to assert `status == ACTIVE` on the round-tripped domain entity. Add to imports: `com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus`.
+
+- [ ] **Step 2: Run new test to verify it fails**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryPersistenceTest.status field round-trips*' --rerun-tasks
+```
+
+Expected: FAIL — `TransactionCategoryStatus` doesn't exist yet (compile error).
+
+- [ ] **Step 3: Create `TransactionCategoryStatus` enum**
+
+Create `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryStatus.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.domain
+
+enum class TransactionCategoryStatus {
+    ACTIVE,
+    INACTIVE,
+}
+```
+
+- [ ] **Step 4: Add `status` field to domain class**
+
+Replace `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategory.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.domain
+
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import com.github.f4b6a3.ulid.Ulid
+import java.time.Instant
+
+data class TransactionCategory(
+    val id: Ulid,
+    val churchId: Ulid,
+    val createdAt: Instant,
+    val addedBy: Ulid,
+    val name: String,
+    val transactionType: FinancialTransactionType,
+    val status: TransactionCategoryStatus = TransactionCategoryStatus.ACTIVE,
+    val version: Long = 0,
+) {
+    init {
+        require(name.isNotBlank()) {
+            "Name must not be blank"
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Add `status` column to JPA entity**
+
+Replace `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryJpaEntity.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.persistence
+
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "transaction_category", schema = "church_finance")
+class TransactionCategoryJpaEntity(
+    @Id
+    var id: UUID,
+    var churchId: UUID,
+    var createdAt: Instant,
+    var addedBy: UUID,
+    var name: String,
+    @Enumerated(EnumType.STRING)
+    var transactionType: FinancialTransactionType,
+    @Enumerated(EnumType.STRING)
+    var status: TransactionCategoryStatus = TransactionCategoryStatus.ACTIVE,
+    @Version
+    var version: Long = 0,
+)
+```
+
+- [ ] **Step 6: Update mapper to round-trip status**
+
+Replace `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryMapper.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.persistence
+
+import com.calvintech.churchfinance.administration.domain.TransactionCategory
+import com.github.f4b6a3.ulid.Ulid
+import org.springframework.stereotype.Component
+
+@Component
+class TransactionCategoryMapper {
+    fun toDomain(entity: TransactionCategoryJpaEntity): TransactionCategory =
+        TransactionCategory(
+            id = Ulid.from(entity.id),
+            churchId = Ulid.from(entity.churchId),
+            createdAt = entity.createdAt,
+            name = entity.name,
+            addedBy = Ulid.from(entity.addedBy),
+            transactionType = entity.transactionType,
+            status = entity.status,
+            version = entity.version,
+        )
+
+    fun toJpaEntity(category: TransactionCategory): TransactionCategoryJpaEntity =
+        TransactionCategoryJpaEntity(
+            id = category.id.toUuid(),
+            churchId = category.churchId.toUuid(),
+            createdAt = category.createdAt,
+            addedBy = category.addedBy.toUuid(),
+            name = category.name,
+            transactionType = category.transactionType,
+            status = category.status,
+            version = category.version,
+        )
+}
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryPersistenceTest*' --rerun-tasks
+```
+
+Expected: all persistence tests PASS, including the new round-trip test.
+
+- [ ] **Step 8: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryStatus.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategory.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryJpaEntity.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryMapper.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
+git commit -m "feat: add status field to TransactionCategory domain and JPA
+
+Introduces TransactionCategoryStatus (ACTIVE/INACTIVE) and threads
+it through the domain entity, JPA entity, and mapper. Persistence
+test now asserts the field round-trips correctly."
+```
+
+---
+
+## Task 3: Add `status` to `TransactionCategoryResponse`; fix existing create-201 test
+
+**Files:**
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryResponse.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt`
+
+- [ ] **Step 1: Update existing integration test to expect status**
+
+In `TransactionCategoryIntegrationTest.kt`, find the existing test `POST should create a transaction category and return 201`. Add one expectation:
+
+```kotlin
+.andExpect(jsonPath("$.status").value("ACTIVE"))
+```
+
+…inserted after the existing `jsonPath("$.type")` expectation.
+
+- [ ] **Step 2: Run test to confirm it fails**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryIntegrationTest*' --rerun-tasks
+```
+
+Expected: FAIL — `status` field doesn't exist on the response yet.
+
+- [ ] **Step 3: Add `status` to response DTO**
+
+Replace `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryResponse.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.api
+
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import java.util.UUID
+
+data class TransactionCategoryResponse(
+    val id: UUID,
+    val name: String,
+    val type: FinancialTransactionType,
+    val status: TransactionCategoryStatus,
+    val version: Long,
+)
+```
+
+- [ ] **Step 4: Update service `toResponse` to set `status`**
+
+In `TransactionCategoryService.kt`, replace the `toResponse` private method:
+
+```kotlin
+private fun toResponse(transactionCategory: TransactionCategory): TransactionCategoryResponse =
+    TransactionCategoryResponse(
+        id = transactionCategory.id.toUuid(),
+        name = transactionCategory.name,
+        type = transactionCategory.transactionType,
+        status = transactionCategory.status,
+        version = transactionCategory.version,
+    )
+```
+
+(`create` already builds the `TransactionCategory` with the default `status = ACTIVE` from Task 2's domain change — no change needed there.)
+
+- [ ] **Step 5: Update existing service unit test**
+
+In `TransactionCategoryTest.kt` (service test), the existing `create should persist and return a new transaction category` test still passes because `buildTransactionCategory` defaults to ACTIVE. No change required, but add `assertEquals(TransactionCategoryStatus.ACTIVE, response.status)` near the existing assertions as belt-and-braces coverage. Add the import.
+
+- [ ] **Step 6: Run tests**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryIntegrationTest*' --tests='*TransactionCategoryTest*' --rerun-tasks
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryResponse.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt
+git commit -m "feat: expose status on TransactionCategoryResponse"
+```
+
+---
+
+## Task 4: Add new exception types and global handlers
+
+**Files:**
+- Create: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNotFoundException.kt`
+- Create: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNameConflictException.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/shared/api/GlobalExceptionHandler.kt`
+
+This task is exception types + their handlers — no test in this task because the handlers can't be tested in isolation; they're exercised by integration tests starting Task 8.
+
+- [ ] **Step 1: Create `TransactionCategoryNotFoundException`**
+
+Create `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNotFoundException.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.domain
+
+import java.util.UUID
+
+class TransactionCategoryNotFoundException(
+    id: UUID,
+) : RuntimeException("Transaction category not found: $id")
+```
+
+- [ ] **Step 2: Create `TransactionCategoryNameConflictException`**
+
+Create `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNameConflictException.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.domain
+
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import java.util.UUID
+
+class TransactionCategoryNameConflictException(
+    churchId: UUID,
+    name: String,
+    type: FinancialTransactionType,
+) : RuntimeException(
+    "A category named '$name' already exists for $type in this church.",
+)
+```
+
+- [ ] **Step 3: Add handlers to `GlobalExceptionHandler`**
+
+Replace `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/shared/api/GlobalExceptionHandler.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.shared.api
+
+import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryNotFoundException
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.http.HttpStatus
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(ChurchNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun handleChurchNotFound(ex: ChurchNotFoundException): ErrorResponse = ErrorResponse(ex.message ?: "Church not found")
+
+    @ExceptionHandler(TransactionCategoryNotFoundException::class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    fun handleTransactionCategoryNotFound(ex: TransactionCategoryNotFoundException): ErrorResponse =
+        ErrorResponse(ex.message ?: "Transaction category not found")
+
+    @ExceptionHandler(TransactionCategoryNameConflictException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    fun handleTransactionCategoryNameConflict(ex: TransactionCategoryNameConflictException): ErrorResponse =
+        ErrorResponse(ex.message ?: "Category name conflict")
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    fun handleValidation(ex: MethodArgumentNotValidException): ErrorResponse {
+        val message =
+            ex.bindingResult.fieldErrors
+                .joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
+                .ifBlank { "Validation failed" }
+        return ErrorResponse(message)
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    fun handleOptimisticLock(): ErrorResponse = ErrorResponse("Someone else has made a change. Please refresh and try again.")
+
+    @ExceptionHandler(DataIntegrityViolationException::class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    fun handleDataIntegrityViolation(): ErrorResponse = ErrorResponse("Conflict — please refresh and try again.")
+}
+```
+
+- [ ] **Step 4: Compile-check**
+
+```bash
+./gradlew :church-finance-backend:compileKotlin
+```
+
+Expected: SUCCESS — no compile errors.
+
+- [ ] **Step 5: Run existing test suite to confirm no regression**
+
+```bash
+./gradlew :church-finance-backend:test --rerun-tasks
+```
+
+Expected: all existing tests still PASS.
+
+- [ ] **Step 6: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNotFoundException.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/domain/TransactionCategoryNameConflictException.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/shared/api/GlobalExceptionHandler.kt
+git commit -m "feat: add TransactionCategory domain exceptions and HTTP handlers
+
+Adds TransactionCategoryNotFoundException (404) and
+TransactionCategoryNameConflictException (409) with handlers in
+GlobalExceptionHandler. Adds DataIntegrityViolationException
+handler (409) as a TOCTOU safety net for the unique constraint."
+```
+
+---
+
+## Task 5: Add repository derived-query methods
+
+**Files:**
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryRepository.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt`
+
+- [ ] **Step 1: Write failing tests**
+
+Add to `TransactionCategoryPersistenceTest.kt`:
+
+```kotlin
+@Test
+fun `findByChurchIdAndNameAndTransactionType returns matching category`() {
+    val churchId = persistChurch()
+    val entity = buildJpaEntity(churchId = churchId, name = "Offerings", type = FinancialTransactionType.INCOME)
+    transactionCategoryRepository.saveAndFlush(entity)
+
+    val found = transactionCategoryRepository.findByChurchIdAndNameAndTransactionType(
+        churchId = churchId,
+        name = "Offerings",
+        transactionType = FinancialTransactionType.INCOME,
+    )
+
+    assertNotNull(found)
+    assertEquals(entity.id, found.id)
+}
+
+@Test
+fun `findByChurchIdAndNameAndTransactionType returns null when type differs`() {
+    val churchId = persistChurch()
+    transactionCategoryRepository.saveAndFlush(
+        buildJpaEntity(churchId = churchId, name = "Offerings", type = FinancialTransactionType.INCOME),
+    )
+
+    val found = transactionCategoryRepository.findByChurchIdAndNameAndTransactionType(
+        churchId = churchId,
+        name = "Offerings",
+        transactionType = FinancialTransactionType.EXPENSE,
+    )
+
+    assertNull(found)
+}
+
+@Test
+fun `findAllByChurchId returns only categories for that church`() {
+    val churchOne = persistChurch("Church One")
+    val churchTwo = persistChurch("Church Two")
+    transactionCategoryRepository.saveAndFlush(
+        buildJpaEntity(churchId = churchOne, name = "A", type = FinancialTransactionType.INCOME),
+    )
+    transactionCategoryRepository.saveAndFlush(
+        buildJpaEntity(churchId = churchOne, name = "B", type = FinancialTransactionType.EXPENSE),
+    )
+    transactionCategoryRepository.saveAndFlush(
+        buildJpaEntity(churchId = churchTwo, name = "C", type = FinancialTransactionType.INCOME),
+    )
+
+    val results = transactionCategoryRepository.findAllByChurchId(churchOne)
+
+    assertEquals(2, results.size)
+    assertTrue(results.all { it.churchId == churchOne })
+}
+```
+
+Add to imports: `kotlin.test.assertNotNull`, `kotlin.test.assertNull`, `kotlin.test.assertTrue`.
+
+- [ ] **Step 2: Run tests to confirm they fail**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryPersistenceTest.findBy*' --tests='*TransactionCategoryPersistenceTest.findAllByChurchId*' --rerun-tasks
+```
+
+Expected: FAIL — methods don't exist (compile error).
+
+- [ ] **Step 3: Add methods to repository**
+
+Replace `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryRepository.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.persistence
+
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface TransactionCategoryRepository : JpaRepository<TransactionCategoryJpaEntity, UUID> {
+    fun findByChurchIdAndNameAndTransactionType(
+        churchId: UUID,
+        name: String,
+        transactionType: FinancialTransactionType,
+    ): TransactionCategoryJpaEntity?
+
+    fun findAllByChurchId(churchId: UUID): List<TransactionCategoryJpaEntity>
+}
+```
+
+- [ ] **Step 4: Run tests to confirm they pass**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryPersistenceTest*' --rerun-tasks
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryRepository.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/persistence/TransactionCategoryPersistenceTest.kt
+git commit -m "feat: add TransactionCategoryRepository derived queries"
+```
+
+---
+
+## Task 6: Service — `ChurchRepository` dependency + `requireChurchExists` + create rejects missing church
+
+**Files:**
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt`
+
+- [ ] **Step 1: Write failing service unit test**
+
+In `TransactionCategoryTest.kt`:
+
+1. Add a new MockK field:
+
+```kotlin
+@MockK
+lateinit var churchRepository: ChurchRepository
+```
+
+2. Update the `setUp` constructor call to:
+
+```kotlin
+transactionCategoryService = TransactionCategoryService(mapper, repository, userProvider, churchRepository)
+```
+
+3. In the existing `create should persist...` test, add a stub line so the new helper passes:
+
+```kotlin
+every { churchRepository.existsById(churchId) } returns true
+```
+
+…before the first `every { userProvider... }` line. Otherwise the existing test will start failing.
+
+4. Add the new test:
+
+```kotlin
+@Test
+fun `create throws ChurchNotFoundException when church does not exist`() {
+    val churchId = UUID.randomUUID()
+    every { churchRepository.existsById(churchId) } returns false
+
+    assertFailsWith<ChurchNotFoundException> {
+        transactionCategoryService.create(
+            churchId,
+            CreateTransactionCategoryRequest(name = "Offerings", type = FinancialTransactionType.INCOME),
+        )
+    }
+}
+```
+
+Add imports: `ChurchRepository`, `ChurchNotFoundException`, `kotlin.test.assertFailsWith`.
+
+- [ ] **Step 2: Write failing integration test**
+
+In `TransactionCategoryIntegrationTest.kt`, add:
+
+```kotlin
+@Test
+fun `POST should return 404 when church does not exist`() {
+    val unknownChurchId = UUID.randomUUID()
+    mockMvc
+        .perform(
+            post("/api/v1/churches/{churchId}/transaction-categories", unknownChurchId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"name": "Offerings", "type": "INCOME"}"""),
+        ).andExpect(status().isNotFound)
+        .andExpect(jsonPath("$.message").exists())
+}
+```
+
+- [ ] **Step 3: Run tests to confirm they fail**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest.create throws ChurchNotFoundException*' --tests='*TransactionCategoryIntegrationTest.POST should return 404*' --rerun-tasks
+```
+
+Expected: FAIL (the integration test currently returns 500 due to FK violation; the service test fails because the helper doesn't exist).
+
+- [ ] **Step 4: Update service to inject `ChurchRepository` and gate `create` on existence**
+
+Replace `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.service
+
+import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
+import com.calvintech.churchfinance.administration.api.TransactionCategoryResponse
+import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
+import com.calvintech.churchfinance.administration.domain.TransactionCategory
+import com.calvintech.churchfinance.administration.persistence.ChurchRepository
+import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
+import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
+import com.calvintech.churchfinance.shared.service.CurrentUserProvider
+import com.github.f4b6a3.ulid.Ulid
+import com.github.f4b6a3.ulid.UlidCreator
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class TransactionCategoryService(
+    private val mapper: TransactionCategoryMapper,
+    private val repository: TransactionCategoryRepository,
+    private val userProvider: CurrentUserProvider,
+    private val churchRepository: ChurchRepository,
+) {
+    fun create(
+        churchId: UUID,
+        createTransactionCategoryRequest: CreateTransactionCategoryRequest,
+    ): TransactionCategoryResponse {
+        requireChurchExists(churchId)
+
+        val transactionCategory =
+            TransactionCategory(
+                id = UlidCreator.getUlid(),
+                churchId = Ulid.from(churchId),
+                createdAt = Instant.now(),
+                addedBy = userProvider.getCurrentUserId(),
+                name = createTransactionCategoryRequest.name,
+                transactionType = createTransactionCategoryRequest.type,
+            )
+
+        return saveAndRespond(transactionCategory)
+    }
+
+    private fun requireChurchExists(churchId: UUID) {
+        if (!churchRepository.existsById(churchId)) {
+            throw ChurchNotFoundException(churchId)
+        }
+    }
+
+    private fun saveAndRespond(transactionCategory: TransactionCategory): TransactionCategoryResponse {
+        val persisted = repository.save(mapper.toJpaEntity(transactionCategory))
+        return toResponse(mapper.toDomain(persisted))
+    }
+
+    private fun toResponse(transactionCategory: TransactionCategory): TransactionCategoryResponse =
+        TransactionCategoryResponse(
+            id = transactionCategory.id.toUuid(),
+            name = transactionCategory.name,
+            type = transactionCategory.transactionType,
+            status = transactionCategory.status,
+            version = transactionCategory.version,
+        )
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest*' --tests='*TransactionCategoryIntegrationTest*' --rerun-tasks
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+git commit -m "feat: gate create on church existence with 404 response"
+```
+
+---
+
+## Task 7: Service — `requireNameAvailable` helper + create rejects name conflict
+
+**Files:**
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt`
+
+- [ ] **Step 1: Write failing service test**
+
+In `TransactionCategoryTest.kt`:
+
+```kotlin
+@Test
+fun `create throws TransactionCategoryNameConflictException when (church, name, type) already exists`() {
+    val churchId = UUID.randomUUID()
+    val existing = buildTransactionCategoryJpaEntity(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+
+    every { churchRepository.existsById(churchId) } returns true
+    every {
+        repository.findByChurchIdAndNameAndTransactionType(
+            churchId = churchId,
+            name = "Offerings",
+            transactionType = FinancialTransactionType.INCOME,
+        )
+    } returns existing
+
+    assertFailsWith<TransactionCategoryNameConflictException> {
+        transactionCategoryService.create(
+            churchId,
+            CreateTransactionCategoryRequest(name = "Offerings", type = FinancialTransactionType.INCOME),
+        )
+    }
+}
+```
+
+Then update the existing `create should persist...` test: after `every { churchRepository.existsById(...) } returns true`, add:
+
+```kotlin
+every {
+    repository.findByChurchIdAndNameAndTransactionType(
+        churchId = churchId,
+        name = "Offerings",
+        transactionType = FinancialTransactionType.INCOME,
+    )
+} returns null
+```
+
+Add import: `TransactionCategoryNameConflictException`.
+
+- [ ] **Step 2: Write failing integration tests**
+
+In `TransactionCategoryIntegrationTest.kt`. First extract a small helper at the top of the class to reduce duplication:
+
+```kotlin
+private fun postCategory(churchId: UUID, name: String, type: String) =
+    mockMvc.perform(
+        post("/api/v1/churches/{churchId}/transaction-categories", churchId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "$name", "type": "$type"}"""),
+    )
+```
+
+Then add:
+
+```kotlin
+@Test
+fun `POST should return 409 when name already exists for the same type in the same church`() {
+    val churchId = UUID.fromString(createChurch())
+    postCategory(churchId, "Tithes", "INCOME").andExpect(status().isCreated)
+
+    postCategory(churchId, "Tithes", "INCOME")
+        .andExpect(status().isConflict)
+        .andExpect(jsonPath("$.message").exists())
+}
+
+@Test
+fun `POST should return 201 when name exists but for a different type`() {
+    val churchId = UUID.fromString(createChurch())
+    postCategory(churchId, "Tithes", "INCOME").andExpect(status().isCreated)
+
+    postCategory(churchId, "Tithes", "EXPENSE").andExpect(status().isCreated)
+}
+```
+
+- [ ] **Step 3: Run tests to confirm failure**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest*' --tests='*TransactionCategoryIntegrationTest*' --rerun-tasks
+```
+
+Expected: new tests FAIL — service has no uniqueness pre-check yet.
+
+- [ ] **Step 4: Update service with `requireNameAvailable`**
+
+Replace `TransactionCategoryService.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.service
+
+import com.calvintech.churchfinance.administration.api.CreateTransactionCategoryRequest
+import com.calvintech.churchfinance.administration.api.TransactionCategoryResponse
+import com.calvintech.churchfinance.administration.domain.ChurchNotFoundException
+import com.calvintech.churchfinance.administration.domain.TransactionCategory
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryNameConflictException
+import com.calvintech.churchfinance.administration.persistence.ChurchRepository
+import com.calvintech.churchfinance.administration.persistence.TransactionCategoryMapper
+import com.calvintech.churchfinance.administration.persistence.TransactionCategoryRepository
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import com.calvintech.churchfinance.shared.service.CurrentUserProvider
+import com.github.f4b6a3.ulid.Ulid
+import com.github.f4b6a3.ulid.UlidCreator
+import org.springframework.stereotype.Service
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class TransactionCategoryService(
+    private val mapper: TransactionCategoryMapper,
+    private val repository: TransactionCategoryRepository,
+    private val userProvider: CurrentUserProvider,
+    private val churchRepository: ChurchRepository,
+) {
+    fun create(
+        churchId: UUID,
+        createTransactionCategoryRequest: CreateTransactionCategoryRequest,
+    ): TransactionCategoryResponse {
+        requireChurchExists(churchId)
+        requireNameAvailable(
+            churchId = churchId,
+            name = createTransactionCategoryRequest.name,
+            type = createTransactionCategoryRequest.type,
+            excludingId = null,
+        )
+
+        val transactionCategory =
+            TransactionCategory(
+                id = UlidCreator.getUlid(),
+                churchId = Ulid.from(churchId),
+                createdAt = Instant.now(),
+                addedBy = userProvider.getCurrentUserId(),
+                name = createTransactionCategoryRequest.name,
+                transactionType = createTransactionCategoryRequest.type,
+            )
+
+        return saveAndRespond(transactionCategory)
+    }
+
+    private fun requireChurchExists(churchId: UUID) {
+        if (!churchRepository.existsById(churchId)) {
+            throw ChurchNotFoundException(churchId)
+        }
+    }
+
+    private fun requireNameAvailable(
+        churchId: UUID,
+        name: String,
+        type: FinancialTransactionType,
+        excludingId: UUID?,
+    ) {
+        val conflict = repository.findByChurchIdAndNameAndTransactionType(
+            churchId = churchId,
+            name = name,
+            transactionType = type,
+        )
+        if (conflict != null && conflict.id != excludingId) {
+            throw TransactionCategoryNameConflictException(churchId, name, type)
+        }
+    }
+
+    private fun saveAndRespond(transactionCategory: TransactionCategory): TransactionCategoryResponse {
+        val persisted = repository.save(mapper.toJpaEntity(transactionCategory))
+        return toResponse(mapper.toDomain(persisted))
+    }
+
+    private fun toResponse(transactionCategory: TransactionCategory): TransactionCategoryResponse =
+        TransactionCategoryResponse(
+            id = transactionCategory.id.toUuid(),
+            name = transactionCategory.name,
+            type = transactionCategory.transactionType,
+            status = transactionCategory.status,
+            version = transactionCategory.version,
+        )
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest*' --tests='*TransactionCategoryIntegrationTest*' --rerun-tasks
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+git commit -m "feat: pre-emptive uniqueness check on category create
+
+Service queries (church_id, name, transaction_type) before
+insert and throws TransactionCategoryNameConflictException
+when the slot is taken. DB constraint remains the safety net."
+```
+
+---
+
+## Task 8: Service `get()` + `findCategoryScopedToChurch` helper + controller GET-by-id
+
+**Files:**
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt`
+
+- [ ] **Step 1: Write failing service unit tests**
+
+Add to `TransactionCategoryTest.kt`:
+
+```kotlin
+@Test
+fun `get returns category when it belongs to the church`() {
+    val churchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val entity = buildTransactionCategoryJpaEntity(id = id, name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId }
+    val domain = buildTransactionCategory(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+
+    every { repository.findById(id) } returns java.util.Optional.of(entity)
+    every { mapper.toDomain(entity) } returns domain.copy(churchId = Ulid.from(churchId))
+
+    val response = transactionCategoryService.get(churchId, id)
+
+    assertEquals("Offerings", response.name)
+}
+
+@Test
+fun `get throws TransactionCategoryNotFoundException when id unknown`() {
+    val churchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    every { repository.findById(id) } returns java.util.Optional.empty()
+
+    assertFailsWith<TransactionCategoryNotFoundException> {
+        transactionCategoryService.get(churchId, id)
+    }
+}
+
+@Test
+fun `get throws TransactionCategoryNotFoundException when category belongs to a different church`() {
+    val urlChurchId = UUID.randomUUID()
+    val actualChurchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val entity = buildTransactionCategoryJpaEntity(id = id, name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = actualChurchId }
+    val domain = buildTransactionCategory(name = "Offerings", transactionType = FinancialTransactionType.INCOME)
+        .copy(churchId = Ulid.from(actualChurchId))
+
+    every { repository.findById(id) } returns java.util.Optional.of(entity)
+    every { mapper.toDomain(entity) } returns domain
+
+    assertFailsWith<TransactionCategoryNotFoundException> {
+        transactionCategoryService.get(urlChurchId, id)
+    }
+}
+```
+
+Imports: `com.github.f4b6a3.ulid.Ulid`, `TransactionCategoryNotFoundException`.
+
+- [ ] **Step 2: Write failing integration tests**
+
+In `TransactionCategoryIntegrationTest.kt`, add a helper:
+
+```kotlin
+private fun createCategoryAndReturnBody(
+    churchId: UUID,
+    name: String = "Offerings",
+    type: String = "INCOME",
+): String =
+    mockMvc.perform(
+        post("/api/v1/churches/{churchId}/transaction-categories", churchId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "$name", "type": "$type"}"""),
+    ).andExpect(status().isCreated)
+        .andReturn().response.contentAsString
+
+private fun extractId(body: String): String = objectMapper.readTree(body).get("id").asString()
+```
+
+Add tests:
+
+```kotlin
+@Test
+fun `GET by id returns the category`() {
+    val churchId = UUID.fromString(createChurch())
+    val id = extractId(createCategoryAndReturnBody(churchId, "Tithes", "INCOME"))
+
+    mockMvc.perform(get("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id))
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.id").value(id))
+        .andExpect(jsonPath("$.name").value("Tithes"))
+        .andExpect(jsonPath("$.type").value("INCOME"))
+        .andExpect(jsonPath("$.status").value("ACTIVE"))
+}
+
+@Test
+fun `GET by id returns 404 when category does not exist`() {
+    val churchId = UUID.fromString(createChurch())
+    val unknownId = UUID.randomUUID()
+
+    mockMvc.perform(get("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, unknownId))
+        .andExpect(status().isNotFound)
+}
+
+@Test
+fun `GET by id returns 404 when category belongs to a different church`() {
+    val churchOne = UUID.fromString(createChurch("Church One"))
+    val churchTwo = UUID.fromString(createChurch("Church Two"))
+    val id = extractId(createCategoryAndReturnBody(churchOne, "Tithes", "INCOME"))
+
+    mockMvc.perform(get("/api/v1/churches/{churchId}/transaction-categories/{id}", churchTwo, id))
+        .andExpect(status().isNotFound)
+}
+```
+
+Add to imports if missing: `org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get`.
+
+- [ ] **Step 3: Run tests to verify failures**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest.get *' --tests='*TransactionCategoryIntegrationTest.GET by id*' --rerun-tasks
+```
+
+Expected: FAIL — service method and controller endpoint don't exist.
+
+- [ ] **Step 4: Add `findCategoryScopedToChurch` + `get()` to service**
+
+Add these methods inside `TransactionCategoryService` (between existing methods):
+
+```kotlin
+fun get(churchId: UUID, id: UUID): TransactionCategoryResponse =
+    toResponse(findCategoryScopedToChurch(churchId, id))
+
+private fun findCategoryScopedToChurch(churchId: UUID, id: UUID): TransactionCategory {
+    val entity = repository.findById(id).orElseThrow { TransactionCategoryNotFoundException(id) }
+    val domain = mapper.toDomain(entity)
+    if (domain.churchId.toUuid() != churchId) {
+        throw TransactionCategoryNotFoundException(id)
+    }
+    return domain
+}
+```
+
+Add import: `com.calvintech.churchfinance.administration.domain.TransactionCategoryNotFoundException`.
+
+- [ ] **Step 5: Add GET-by-id endpoint to controller**
+
+Edit `TransactionCategoryController.kt`. Add the import for `GetMapping`:
+
+```kotlin
+import org.springframework.web.bind.annotation.GetMapping
+```
+
+Then add the endpoint method inside the controller class:
+
+```kotlin
+@GetMapping("/{id}")
+@Operation(
+    summary = "Get a transaction category by id",
+    description = "Returns the transaction category identified by its UUID, scoped to the supplied church.",
+)
+@ApiResponses(
+    value = [
+        ApiResponse(responseCode = "200", description = "Transaction category found"),
+        ApiResponse(responseCode = "404", description = "Transaction category not found", content = []),
+    ],
+)
+fun get(
+    @Parameter(description = "Identifier of the church the category belongs to", required = true)
+    @PathVariable churchId: UUID,
+    @Parameter(description = "Identifier of the transaction category", required = true)
+    @PathVariable id: UUID,
+): TransactionCategoryResponse = transactionCategoryService.get(churchId, id)
+```
+
+- [ ] **Step 6: Run tests**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest*' --tests='*TransactionCategoryIntegrationTest*' --rerun-tasks
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+git commit -m "feat: GET /churches/{churchId}/transaction-categories/{id}
+
+Returns the category scoped to the church. Tenant mismatch is
+indistinguishable from not-found to avoid leaking IDs across
+tenants."
+```
+
+---
+
+## Task 9: Service + Controller — `list()` + `TransactionCategoryStatusFilter` + GET list endpoint
+
+**Files:**
+- Create: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryStatusFilter.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt`
+
+- [ ] **Step 1: Write failing service tests**
+
+Add to `TransactionCategoryTest.kt`. First add a small helper:
+
+```kotlin
+private fun jpaList(vararg entities: TransactionCategoryJpaEntity) = entities.toList()
+```
+
+Then the tests:
+
+```kotlin
+@Test
+fun `list returns only ACTIVE categories sorted by name when no filters supplied`() {
+    val churchId = UUID.randomUUID()
+    val active = buildTransactionCategoryJpaEntity(name = "Tithes", transactionType = FinancialTransactionType.INCOME)
+    val inactive = buildTransactionCategoryJpaEntity(name = "Old", transactionType = FinancialTransactionType.INCOME)
+        .also { it.status = TransactionCategoryStatus.INACTIVE }
+
+    every { churchRepository.existsById(churchId) } returns true
+    every { repository.findAllByChurchId(churchId) } returns jpaList(inactive, active)
+    every { mapper.toDomain(active) } returns buildTransactionCategory(name = "Tithes", transactionType = FinancialTransactionType.INCOME)
+    every { mapper.toDomain(inactive) } returns buildTransactionCategory(
+        name = "Old",
+        transactionType = FinancialTransactionType.INCOME,
+    ).copy(status = TransactionCategoryStatus.INACTIVE)
+
+    val result = transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.ACTIVE, type = null)
+
+    assertEquals(1, result.size)
+    assertEquals("Tithes", result.first().name)
+}
+
+@Test
+fun `list with status=ALL returns all rows sorted by name`() {
+    val churchId = UUID.randomUUID()
+    val a = buildTransactionCategoryJpaEntity(name = "Z", transactionType = FinancialTransactionType.INCOME)
+    val b = buildTransactionCategoryJpaEntity(name = "A", transactionType = FinancialTransactionType.EXPENSE)
+        .also { it.status = TransactionCategoryStatus.INACTIVE }
+
+    every { churchRepository.existsById(churchId) } returns true
+    every { repository.findAllByChurchId(churchId) } returns jpaList(a, b)
+    every { mapper.toDomain(a) } returns buildTransactionCategory(name = "Z", transactionType = FinancialTransactionType.INCOME)
+    every { mapper.toDomain(b) } returns buildTransactionCategory(name = "A", transactionType = FinancialTransactionType.EXPENSE)
+        .copy(status = TransactionCategoryStatus.INACTIVE)
+
+    val result = transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.ALL, type = null)
+
+    assertEquals(listOf("A", "Z"), result.map { it.name })
+}
+
+@Test
+fun `list with status=INACTIVE returns only inactive`() {
+    val churchId = UUID.randomUUID()
+    val active = buildTransactionCategoryJpaEntity(name = "X", transactionType = FinancialTransactionType.INCOME)
+    val inactive = buildTransactionCategoryJpaEntity(name = "Y", transactionType = FinancialTransactionType.INCOME)
+        .also { it.status = TransactionCategoryStatus.INACTIVE }
+
+    every { churchRepository.existsById(churchId) } returns true
+    every { repository.findAllByChurchId(churchId) } returns jpaList(active, inactive)
+    every { mapper.toDomain(active) } returns buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+    every { mapper.toDomain(inactive) } returns buildTransactionCategory(name = "Y", transactionType = FinancialTransactionType.INCOME)
+        .copy(status = TransactionCategoryStatus.INACTIVE)
+
+    val result = transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.INACTIVE, type = null)
+
+    assertEquals(listOf("Y"), result.map { it.name })
+}
+
+@Test
+fun `list with type filter returns only matching type`() {
+    val churchId = UUID.randomUUID()
+    val income = buildTransactionCategoryJpaEntity(name = "X", transactionType = FinancialTransactionType.INCOME)
+    val expense = buildTransactionCategoryJpaEntity(name = "Y", transactionType = FinancialTransactionType.EXPENSE)
+
+    every { churchRepository.existsById(churchId) } returns true
+    every { repository.findAllByChurchId(churchId) } returns jpaList(income, expense)
+    every { mapper.toDomain(income) } returns buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+    every { mapper.toDomain(expense) } returns buildTransactionCategory(name = "Y", transactionType = FinancialTransactionType.EXPENSE)
+
+    val result = transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.ACTIVE, type = FinancialTransactionType.INCOME)
+
+    assertEquals(listOf("X"), result.map { it.name })
+}
+
+@Test
+fun `list throws ChurchNotFoundException when church does not exist`() {
+    val churchId = UUID.randomUUID()
+    every { churchRepository.existsById(churchId) } returns false
+
+    assertFailsWith<ChurchNotFoundException> {
+        transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.ACTIVE, type = null)
+    }
+}
+```
+
+Add imports: `TransactionCategoryStatus`, `TransactionCategoryStatusFilter`.
+
+- [ ] **Step 2: Write failing integration tests**
+
+In `TransactionCategoryIntegrationTest.kt`:
+
+```kotlin
+@Test
+fun `GET list returns only ACTIVE categories by default`() {
+    val churchId = UUID.fromString(createChurch())
+    val activeId = extractId(createCategoryAndReturnBody(churchId, "Tithes", "INCOME"))
+    val toDeactivateBody = createCategoryAndReturnBody(churchId, "Old", "INCOME")
+    val toDeactivateId = extractId(toDeactivateBody)
+    // We can't deactivate yet (Task 11). Insert it INACTIVE via PATCH route once it exists.
+    // For now, this test will be updated in Task 11 once deactivate exists.
+    // In this task, assert that the freshly created category appears in the default listing.
+    mockMvc.perform(get("/api/v1/churches/{churchId}/transaction-categories", churchId))
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[*].id", hasItems(activeId, toDeactivateId)))
+}
+
+@Test
+fun `GET list returns empty list when church has no categories`() {
+    val churchId = UUID.fromString(createChurch())
+
+    mockMvc.perform(get("/api/v1/churches/{churchId}/transaction-categories", churchId))
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.length()").value(0))
+}
+
+@Test
+fun `GET list returns 404 when church does not exist`() {
+    val unknownChurchId = UUID.randomUUID()
+
+    mockMvc.perform(get("/api/v1/churches/{churchId}/transaction-categories", unknownChurchId))
+        .andExpect(status().isNotFound)
+}
+
+@Test
+fun `GET list with type=INCOME filters correctly`() {
+    val churchId = UUID.fromString(createChurch())
+    createCategoryAndReturnBody(churchId, "Tithes", "INCOME")
+    createCategoryAndReturnBody(churchId, "Bills", "EXPENSE")
+
+    mockMvc.perform(
+        get("/api/v1/churches/{churchId}/transaction-categories", churchId)
+            .param("type", "INCOME"),
+    )
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].name").value("Tithes"))
+}
+
+@Test
+fun `GET list sorts by name ascending`() {
+    val churchId = UUID.fromString(createChurch())
+    createCategoryAndReturnBody(churchId, "Zebra", "INCOME")
+    createCategoryAndReturnBody(churchId, "Apple", "INCOME")
+    createCategoryAndReturnBody(churchId, "Mango", "INCOME")
+
+    mockMvc.perform(get("/api/v1/churches/{churchId}/transaction-categories", churchId))
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$[0].name").value("Apple"))
+        .andExpect(jsonPath("$[1].name").value("Mango"))
+        .andExpect(jsonPath("$[2].name").value("Zebra"))
+}
+```
+
+Add imports: `org.hamcrest.Matchers.hasItems`.
+
+(The status=ALL and "deactivated excluded from default" tests come in Task 11 after deactivate exists.)
+
+- [ ] **Step 3: Run tests to confirm failure**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest.list*' --tests='*TransactionCategoryIntegrationTest.GET list*' --rerun-tasks
+```
+
+Expected: FAIL — `list` method and endpoint don't exist; the filter enum doesn't exist.
+
+- [ ] **Step 4: Create `TransactionCategoryStatusFilter`**
+
+Create `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryStatusFilter.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.api
+
+import com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus
+
+enum class TransactionCategoryStatusFilter {
+    ACTIVE,
+    INACTIVE,
+    ALL,
+    ;
+
+    fun matches(status: TransactionCategoryStatus): Boolean =
+        when (this) {
+            ALL -> true
+            ACTIVE -> status == TransactionCategoryStatus.ACTIVE
+            INACTIVE -> status == TransactionCategoryStatus.INACTIVE
+        }
+}
+```
+
+- [ ] **Step 5: Add `list()` to service**
+
+In `TransactionCategoryService.kt`, add the import:
+
+```kotlin
+import com.calvintech.churchfinance.administration.api.TransactionCategoryStatusFilter
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+```
+
+Then add the method (place it near the other public methods):
+
+```kotlin
+fun list(
+    churchId: UUID,
+    status: TransactionCategoryStatusFilter,
+    type: FinancialTransactionType?,
+): List<TransactionCategoryResponse> {
+    requireChurchExists(churchId)
+    return repository.findAllByChurchId(churchId)
+        .map(mapper::toDomain)
+        .filter { status.matches(it.status) }
+        .filter { type == null || it.transactionType == type }
+        .sortedBy { it.name }
+        .map(::toResponse)
+}
+```
+
+- [ ] **Step 6: Add GET list endpoint to controller**
+
+In `TransactionCategoryController.kt`, add imports:
+
+```kotlin
+import com.calvintech.churchfinance.shared.domain.FinancialTransactionType
+import org.springframework.web.bind.annotation.RequestParam
+```
+
+Then add the endpoint method:
+
+```kotlin
+@GetMapping
+@Operation(
+    summary = "List transaction categories for a church",
+    description = "Returns categories for the supplied church. Defaults to ACTIVE only; use `status=ALL` or `status=INACTIVE` to broaden, and `type=INCOME` or `type=EXPENSE` to narrow.",
+)
+@ApiResponses(
+    value = [
+        ApiResponse(responseCode = "200", description = "Categories returned"),
+        ApiResponse(responseCode = "404", description = "Church not found", content = []),
+    ],
+)
+fun list(
+    @Parameter(description = "Identifier of the church", required = true)
+    @PathVariable churchId: UUID,
+    @Parameter(description = "Status filter (default ACTIVE)")
+    @RequestParam(defaultValue = "ACTIVE") status: TransactionCategoryStatusFilter,
+    @Parameter(description = "Optional transaction type filter")
+    @RequestParam(required = false) type: FinancialTransactionType?,
+): List<TransactionCategoryResponse> = transactionCategoryService.list(churchId, status, type)
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest*' --tests='*TransactionCategoryIntegrationTest*' --rerun-tasks
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryStatusFilter.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+git commit -m "feat: GET /churches/{churchId}/transaction-categories with filters
+
+Adds list endpoint with status (default ACTIVE) and optional
+type filter, sorted by name ascending. Service-side filtering
+over a single findAllByChurchId query."
+```
+
+---
+
+## Task 10: Service `update()` + `UpdateTransactionCategoryRequest` DTO + PUT endpoint
+
+**Files:**
+- Create: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/UpdateTransactionCategoryRequest.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt`
+
+- [ ] **Step 1: Write failing service unit tests**
+
+Add to `TransactionCategoryTest.kt`:
+
+```kotlin
+@Test
+fun `update changes name and returns updated response`() {
+    val churchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val existing = buildTransactionCategoryJpaEntity(id = id, name = "Old", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId }
+    val existingDomain = buildTransactionCategory(name = "Old", transactionType = FinancialTransactionType.INCOME)
+        .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
+    val saved = buildTransactionCategoryJpaEntity(id = id, name = "New", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId; it.version = 1 }
+    val savedDomain = buildTransactionCategory(name = "New", transactionType = FinancialTransactionType.INCOME)
+        .copy(id = Ulid.from(id), churchId = Ulid.from(churchId), version = 1)
+
+    every { repository.findById(id) } returns java.util.Optional.of(existing)
+    every { mapper.toDomain(existing) } returns existingDomain
+    every {
+        repository.findByChurchIdAndNameAndTransactionType(churchId, "New", FinancialTransactionType.INCOME)
+    } returns null
+    every { mapper.toJpaEntity(any()) } returns saved
+    every { repository.save(saved) } returns saved
+    every { mapper.toDomain(saved) } returns savedDomain
+
+    val response = transactionCategoryService.update(
+        churchId = churchId,
+        id = id,
+        req = UpdateTransactionCategoryRequest(name = "New", version = 0),
+    )
+
+    assertEquals("New", response.name)
+}
+
+@Test
+fun `update skips uniqueness check when name is unchanged`() {
+    val churchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val existing = buildTransactionCategoryJpaEntity(id = id, name = "Same", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId }
+    val existingDomain = buildTransactionCategory(name = "Same", transactionType = FinancialTransactionType.INCOME)
+        .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
+
+    every { repository.findById(id) } returns java.util.Optional.of(existing)
+    every { mapper.toDomain(existing) } returns existingDomain
+    every { mapper.toJpaEntity(any()) } returns existing
+    every { repository.save(existing) } returns existing
+    every { mapper.toDomain(existing) } returns existingDomain
+
+    transactionCategoryService.update(
+        churchId = churchId,
+        id = id,
+        req = UpdateTransactionCategoryRequest(name = "Same", version = 0),
+    )
+
+    verify(exactly = 0) {
+        repository.findByChurchIdAndNameAndTransactionType(any(), any(), any())
+    }
+}
+
+@Test
+fun `update throws conflict when new name collides with another category of the same type`() {
+    val churchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val collidingId = UUID.randomUUID()
+    val existing = buildTransactionCategoryJpaEntity(id = id, name = "Old", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId }
+    val existingDomain = buildTransactionCategory(name = "Old", transactionType = FinancialTransactionType.INCOME)
+        .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
+    val colliding = buildTransactionCategoryJpaEntity(id = collidingId, name = "Taken", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId }
+
+    every { repository.findById(id) } returns java.util.Optional.of(existing)
+    every { mapper.toDomain(existing) } returns existingDomain
+    every {
+        repository.findByChurchIdAndNameAndTransactionType(churchId, "Taken", FinancialTransactionType.INCOME)
+    } returns colliding
+
+    assertFailsWith<TransactionCategoryNameConflictException> {
+        transactionCategoryService.update(
+            churchId = churchId,
+            id = id,
+            req = UpdateTransactionCategoryRequest(name = "Taken", version = 0),
+        )
+    }
+}
+
+@Test
+fun `update permits keeping the same name (excludingId guard)`() {
+    val churchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val existing = buildTransactionCategoryJpaEntity(id = id, name = "Old", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId }
+    val existingDomain = buildTransactionCategory(name = "Old", transactionType = FinancialTransactionType.INCOME)
+        .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
+
+    every { repository.findById(id) } returns java.util.Optional.of(existing)
+    every { mapper.toDomain(existing) } returns existingDomain
+    // findBy is NOT called because name is unchanged; covered by the "skips uniqueness check" test.
+    every { mapper.toJpaEntity(any()) } returns existing
+    every { repository.save(existing) } returns existing
+    every { mapper.toDomain(existing) } returns existingDomain
+
+    val response = transactionCategoryService.update(
+        churchId = churchId,
+        id = id,
+        req = UpdateTransactionCategoryRequest(name = "Old", version = 0),
+    )
+
+    assertEquals("Old", response.name)
+}
+
+@Test
+fun `update throws not-found on tenant mismatch`() {
+    val urlChurchId = UUID.randomUUID()
+    val actualChurchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val existing = buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = actualChurchId }
+    val existingDomain = buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+        .copy(id = Ulid.from(id), churchId = Ulid.from(actualChurchId))
+
+    every { repository.findById(id) } returns java.util.Optional.of(existing)
+    every { mapper.toDomain(existing) } returns existingDomain
+
+    assertFailsWith<TransactionCategoryNotFoundException> {
+        transactionCategoryService.update(
+            churchId = urlChurchId,
+            id = id,
+            req = UpdateTransactionCategoryRequest(name = "Y", version = 0),
+        )
+    }
+}
+```
+
+Imports: `UpdateTransactionCategoryRequest`, `io.mockk.verify`.
+
+- [ ] **Step 2: Write failing integration tests**
+
+In `TransactionCategoryIntegrationTest.kt`:
+
+```kotlin
+@Test
+fun `PUT updates name and returns 200`() {
+    val churchId = UUID.fromString(createChurch())
+    val id = extractId(createCategoryAndReturnBody(churchId, "Old", "INCOME"))
+
+    mockMvc.perform(
+        put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "New", "version": 0}"""),
+    )
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.name").value("New"))
+}
+
+@Test
+fun `PUT returns 400 on blank name`() {
+    val churchId = UUID.fromString(createChurch())
+    val id = extractId(createCategoryAndReturnBody(churchId, "Old", "INCOME"))
+
+    mockMvc.perform(
+        put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "", "version": 0}"""),
+    )
+        .andExpect(status().isBadRequest)
+        .andExpect(jsonPath("$.message").exists())
+}
+
+@Test
+fun `PUT returns 404 on unknown id`() {
+    val churchId = UUID.fromString(createChurch())
+    val unknownId = UUID.randomUUID()
+
+    mockMvc.perform(
+        put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, unknownId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "Anything", "version": 0}"""),
+    )
+        .andExpect(status().isNotFound)
+}
+
+@Test
+fun `PUT returns 404 on tenant mismatch`() {
+    val churchOne = UUID.fromString(createChurch("Church One"))
+    val churchTwo = UUID.fromString(createChurch("Church Two"))
+    val id = extractId(createCategoryAndReturnBody(churchOne, "Tithes", "INCOME"))
+
+    mockMvc.perform(
+        put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchTwo, id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "Renamed", "version": 0}"""),
+    )
+        .andExpect(status().isNotFound)
+}
+
+@Test
+fun `PUT returns 409 when stale version`() {
+    val churchId = UUID.fromString(createChurch())
+    val id = extractId(createCategoryAndReturnBody(churchId, "Old", "INCOME"))
+
+    mockMvc.perform(
+        put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "First Update", "version": 0}"""),
+    ).andExpect(status().isOk)
+
+    mockMvc.perform(
+        put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "Stale Update", "version": 0}"""),
+    )
+        .andExpect(status().isConflict)
+        .andExpect(jsonPath("$.message").value("Someone else has made a change. Please refresh and try again."))
+}
+
+@Test
+fun `PUT returns 409 when new name collides with another category of the same type`() {
+    val churchId = UUID.fromString(createChurch())
+    createCategoryAndReturnBody(churchId, "Taken", "INCOME")
+    val id = extractId(createCategoryAndReturnBody(churchId, "Other", "INCOME"))
+
+    mockMvc.perform(
+        put("/api/v1/churches/{churchId}/transaction-categories/{id}", churchId, id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content("""{"name": "Taken", "version": 0}"""),
+    )
+        .andExpect(status().isConflict)
+        .andExpect(jsonPath("$.message").exists())
+}
+```
+
+Add imports: `org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put`.
+
+- [ ] **Step 3: Run tests to verify failure**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest.update*' --tests='*TransactionCategoryIntegrationTest.PUT*' --rerun-tasks
+```
+
+Expected: FAIL — no `update` method, no DTO, no PUT endpoint.
+
+- [ ] **Step 4: Create `UpdateTransactionCategoryRequest`**
+
+Create `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/UpdateTransactionCategoryRequest.kt`:
+
+```kotlin
+package com.calvintech.churchfinance.administration.api
+
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateTransactionCategoryRequest(
+    @field:NotBlank
+    val name: String,
+    val version: Long,
+)
+```
+
+- [ ] **Step 5: Add `update()` to service**
+
+In `TransactionCategoryService.kt`, add the import:
+
+```kotlin
+import com.calvintech.churchfinance.administration.api.UpdateTransactionCategoryRequest
+```
+
+Add the method (after `get`):
+
+```kotlin
+fun update(
+    churchId: UUID,
+    id: UUID,
+    req: UpdateTransactionCategoryRequest,
+): TransactionCategoryResponse {
+    val existing = findCategoryScopedToChurch(churchId, id)
+    if (existing.name != req.name) {
+        requireNameAvailable(
+            churchId = churchId,
+            name = req.name,
+            type = existing.transactionType,
+            excludingId = id,
+        )
+    }
+    val updated = existing.copy(name = req.name, version = req.version)
+    return saveAndRespond(updated)
+}
+```
+
+- [ ] **Step 6: Add PUT endpoint to controller**
+
+In `TransactionCategoryController.kt`, add imports:
+
+```kotlin
+import com.calvintech.churchfinance.administration.api.UpdateTransactionCategoryRequest
+import org.springframework.web.bind.annotation.PutMapping
+```
+
+Add the endpoint:
+
+```kotlin
+@PutMapping("/{id}")
+@Operation(
+    summary = "Update a transaction category",
+    description = "Updates the category's name. Type is immutable. Requires the current `version` for optimistic locking.",
+)
+@ApiResponses(
+    value = [
+        ApiResponse(responseCode = "200", description = "Transaction category updated"),
+        ApiResponse(responseCode = "400", description = "Validation failure", content = []),
+        ApiResponse(responseCode = "404", description = "Transaction category not found", content = []),
+        ApiResponse(responseCode = "409", description = "Name conflict or optimistic locking conflict", content = []),
+    ],
+)
+fun update(
+    @Parameter(description = "Identifier of the church", required = true)
+    @PathVariable churchId: UUID,
+    @Parameter(description = "Identifier of the transaction category", required = true)
+    @PathVariable id: UUID,
+    @Valid @RequestBody request: UpdateTransactionCategoryRequest,
+): TransactionCategoryResponse = transactionCategoryService.update(churchId, id, request)
+```
+
+- [ ] **Step 7: Run tests**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest*' --tests='*TransactionCategoryIntegrationTest*' --rerun-tasks
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/UpdateTransactionCategoryRequest.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+git commit -m "feat: PUT /churches/{churchId}/transaction-categories/{id}
+
+Updates the category name (type is immutable). Pre-emptive
+uniqueness check only when the name actually changes;
+optimistic locking via version field; tenant-scoped 404."
+```
+
+---
+
+## Task 11: Service `deactivate()` / `activate()` + PATCH endpoints
+
+**Files:**
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt`
+- Modify: `church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt`
+- Modify: `church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt`
+
+- [ ] **Step 1: Write failing service unit tests**
+
+Add to `TransactionCategoryTest.kt`:
+
+```kotlin
+@Test
+fun `deactivate sets status to INACTIVE`() {
+    val churchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val existing = buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId }
+    val existingDomain = buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+        .copy(id = Ulid.from(id), churchId = Ulid.from(churchId))
+    val deactivated = buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId; it.status = TransactionCategoryStatus.INACTIVE; it.version = 1 }
+    val deactivatedDomain = existingDomain.copy(status = TransactionCategoryStatus.INACTIVE, version = 1)
+
+    every { repository.findById(id) } returns java.util.Optional.of(existing)
+    every { mapper.toDomain(existing) } returns existingDomain
+    every { mapper.toJpaEntity(any()) } returns deactivated
+    every { repository.save(deactivated) } returns deactivated
+    every { mapper.toDomain(deactivated) } returns deactivatedDomain
+
+    val response = transactionCategoryService.deactivate(churchId, id, version = 0)
+
+    assertEquals(TransactionCategoryStatus.INACTIVE, response.status)
+}
+
+@Test
+fun `activate sets status to ACTIVE`() {
+    val churchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val existing = buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId; it.status = TransactionCategoryStatus.INACTIVE }
+    val existingDomain = buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+        .copy(id = Ulid.from(id), churchId = Ulid.from(churchId), status = TransactionCategoryStatus.INACTIVE)
+    val activated = buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = churchId; it.version = 2 }
+    val activatedDomain = existingDomain.copy(status = TransactionCategoryStatus.ACTIVE, version = 2)
+
+    every { repository.findById(id) } returns java.util.Optional.of(existing)
+    every { mapper.toDomain(existing) } returns existingDomain
+    every { mapper.toJpaEntity(any()) } returns activated
+    every { repository.save(activated) } returns activated
+    every { mapper.toDomain(activated) } returns activatedDomain
+
+    val response = transactionCategoryService.activate(churchId, id, version = 1)
+
+    assertEquals(TransactionCategoryStatus.ACTIVE, response.status)
+}
+
+@Test
+fun `deactivate throws not-found on tenant mismatch`() {
+    val urlChurchId = UUID.randomUUID()
+    val actualChurchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val existing = buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = actualChurchId }
+    val existingDomain = buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+        .copy(id = Ulid.from(id), churchId = Ulid.from(actualChurchId))
+
+    every { repository.findById(id) } returns java.util.Optional.of(existing)
+    every { mapper.toDomain(existing) } returns existingDomain
+
+    assertFailsWith<TransactionCategoryNotFoundException> {
+        transactionCategoryService.deactivate(urlChurchId, id, version = 0)
+    }
+}
+
+@Test
+fun `activate throws not-found on tenant mismatch`() {
+    val urlChurchId = UUID.randomUUID()
+    val actualChurchId = UUID.randomUUID()
+    val id = UUID.randomUUID()
+    val existing = buildTransactionCategoryJpaEntity(id = id, name = "X", transactionType = FinancialTransactionType.INCOME)
+        .also { it.churchId = actualChurchId }
+    val existingDomain = buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
+        .copy(id = Ulid.from(id), churchId = Ulid.from(actualChurchId))
+
+    every { repository.findById(id) } returns java.util.Optional.of(existing)
+    every { mapper.toDomain(existing) } returns existingDomain
+
+    assertFailsWith<TransactionCategoryNotFoundException> {
+        transactionCategoryService.activate(urlChurchId, id, version = 0)
+    }
+}
+```
+
+- [ ] **Step 2: Write failing integration tests**
+
+In `TransactionCategoryIntegrationTest.kt`:
+
+```kotlin
+@Test
+fun `PATCH deactivate sets status to INACTIVE`() {
+    val churchId = UUID.fromString(createChurch())
+    val id = extractId(createCategoryAndReturnBody(churchId, "X", "INCOME"))
+
+    mockMvc.perform(
+        patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchId, id)
+            .param("version", "0"),
+    )
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.status").value("INACTIVE"))
+}
+
+@Test
+fun `PATCH activate sets status to ACTIVE`() {
+    val churchId = UUID.fromString(createChurch())
+    val id = extractId(createCategoryAndReturnBody(churchId, "X", "INCOME"))
+
+    val deactivateBody = mockMvc.perform(
+        patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchId, id)
+            .param("version", "0"),
+    ).andExpect(status().isOk).andReturn().response.contentAsString
+
+    val newVersion = objectMapper.readTree(deactivateBody).get("version").asString()
+
+    mockMvc.perform(
+        patch("/api/v1/churches/{churchId}/transaction-categories/{id}/activate", churchId, id)
+            .param("version", newVersion),
+    )
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.status").value("ACTIVE"))
+}
+
+@Test
+fun `PATCH deactivate returns 404 on unknown id`() {
+    val churchId = UUID.fromString(createChurch())
+    val unknownId = UUID.randomUUID()
+
+    mockMvc.perform(
+        patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchId, unknownId)
+            .param("version", "0"),
+    ).andExpect(status().isNotFound)
+}
+
+@Test
+fun `PATCH deactivate returns 404 on tenant mismatch`() {
+    val churchOne = UUID.fromString(createChurch("Church One"))
+    val churchTwo = UUID.fromString(createChurch("Church Two"))
+    val id = extractId(createCategoryAndReturnBody(churchOne, "X", "INCOME"))
+
+    mockMvc.perform(
+        patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchTwo, id)
+            .param("version", "0"),
+    ).andExpect(status().isNotFound)
+}
+
+@Test
+fun `PATCH activate returns 404 on unknown id`() {
+    val churchId = UUID.fromString(createChurch())
+    val unknownId = UUID.randomUUID()
+
+    mockMvc.perform(
+        patch("/api/v1/churches/{churchId}/transaction-categories/{id}/activate", churchId, unknownId)
+            .param("version", "0"),
+    ).andExpect(status().isNotFound)
+}
+
+@Test
+fun `PATCH activate returns 404 on tenant mismatch`() {
+    val churchOne = UUID.fromString(createChurch("Church One"))
+    val churchTwo = UUID.fromString(createChurch("Church Two"))
+    val id = extractId(createCategoryAndReturnBody(churchOne, "X", "INCOME"))
+
+    mockMvc.perform(
+        patch("/api/v1/churches/{churchId}/transaction-categories/{id}/activate", churchTwo, id)
+            .param("version", "0"),
+    ).andExpect(status().isNotFound)
+}
+
+@Test
+fun `Deactivated category is excluded from default list but included with status=ALL`() {
+    val churchId = UUID.fromString(createChurch())
+    val activeId = extractId(createCategoryAndReturnBody(churchId, "Active", "INCOME"))
+    val toDeactivateId = extractId(createCategoryAndReturnBody(churchId, "Hidden", "INCOME"))
+
+    mockMvc.perform(
+        patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchId, toDeactivateId)
+            .param("version", "0"),
+    ).andExpect(status().isOk)
+
+    mockMvc.perform(get("/api/v1/churches/{churchId}/transaction-categories", churchId))
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].id").value(activeId))
+
+    mockMvc.perform(
+        get("/api/v1/churches/{churchId}/transaction-categories", churchId)
+            .param("status", "ALL"),
+    )
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.length()").value(2))
+}
+```
+
+Add imports: `org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch`.
+
+- [ ] **Step 3: Run tests to verify failure**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest.deactivate*' --tests='*TransactionCategoryTest.activate*' --tests='*TransactionCategoryIntegrationTest.PATCH*' --tests='*TransactionCategoryIntegrationTest.Deactivated*' --rerun-tasks
+```
+
+Expected: FAIL — methods and endpoints don't exist.
+
+- [ ] **Step 4: Add `deactivate()` and `activate()` to service**
+
+Add to `TransactionCategoryService.kt`:
+
+```kotlin
+fun deactivate(churchId: UUID, id: UUID, version: Long): TransactionCategoryResponse {
+    val existing = findCategoryScopedToChurch(churchId, id)
+    val updated = existing.copy(status = TransactionCategoryStatus.INACTIVE, version = version)
+    return saveAndRespond(updated)
+}
+
+fun activate(churchId: UUID, id: UUID, version: Long): TransactionCategoryResponse {
+    val existing = findCategoryScopedToChurch(churchId, id)
+    val updated = existing.copy(status = TransactionCategoryStatus.ACTIVE, version = version)
+    return saveAndRespond(updated)
+}
+```
+
+Add import: `com.calvintech.churchfinance.administration.domain.TransactionCategoryStatus`.
+
+- [ ] **Step 5: Add PATCH endpoints to controller**
+
+In `TransactionCategoryController.kt`, add import:
+
+```kotlin
+import org.springframework.web.bind.annotation.PatchMapping
+```
+
+Add the two endpoints:
+
+```kotlin
+@PatchMapping("/{id}/deactivate")
+@Operation(
+    summary = "Deactivate a transaction category",
+    description = "Marks the category as INACTIVE. Requires the current `version` for optimistic locking.",
+)
+@ApiResponses(
+    value = [
+        ApiResponse(responseCode = "200", description = "Category deactivated"),
+        ApiResponse(responseCode = "404", description = "Transaction category not found", content = []),
+        ApiResponse(responseCode = "409", description = "Optimistic locking conflict", content = []),
+    ],
+)
+fun deactivate(
+    @Parameter(description = "Identifier of the church", required = true)
+    @PathVariable churchId: UUID,
+    @Parameter(description = "Identifier of the transaction category", required = true)
+    @PathVariable id: UUID,
+    @Parameter(description = "Current version for optimistic locking", required = true)
+    @RequestParam version: Long,
+): TransactionCategoryResponse = transactionCategoryService.deactivate(churchId, id, version)
+
+@PatchMapping("/{id}/activate")
+@Operation(
+    summary = "Activate a transaction category",
+    description = "Marks the category as ACTIVE. Requires the current `version` for optimistic locking.",
+)
+@ApiResponses(
+    value = [
+        ApiResponse(responseCode = "200", description = "Category activated"),
+        ApiResponse(responseCode = "404", description = "Transaction category not found", content = []),
+        ApiResponse(responseCode = "409", description = "Optimistic locking conflict", content = []),
+    ],
+)
+fun activate(
+    @Parameter(description = "Identifier of the church", required = true)
+    @PathVariable churchId: UUID,
+    @Parameter(description = "Identifier of the transaction category", required = true)
+    @PathVariable id: UUID,
+    @Parameter(description = "Current version for optimistic locking", required = true)
+    @RequestParam version: Long,
+): TransactionCategoryResponse = transactionCategoryService.activate(churchId, id, version)
+```
+
+- [ ] **Step 6: Update the placeholder integration test from Task 9**
+
+The Task 9 test `GET list returns only ACTIVE categories by default` contains a comment about updating it once deactivate exists. Find that test and update it to actually deactivate the second category, so it asserts that only the active one appears:
+
+```kotlin
+@Test
+fun `GET list returns only ACTIVE categories by default`() {
+    val churchId = UUID.fromString(createChurch())
+    val activeId = extractId(createCategoryAndReturnBody(churchId, "Tithes", "INCOME"))
+    val toDeactivateId = extractId(createCategoryAndReturnBody(churchId, "Old", "INCOME"))
+
+    mockMvc.perform(
+        patch("/api/v1/churches/{churchId}/transaction-categories/{id}/deactivate", churchId, toDeactivateId)
+            .param("version", "0"),
+    ).andExpect(status().isOk)
+
+    mockMvc.perform(get("/api/v1/churches/{churchId}/transaction-categories", churchId))
+        .andExpect(status().isOk)
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].id").value(activeId))
+}
+```
+
+(There's overlap with `Deactivated category is excluded from default list...` — that's fine, they're checking slightly different angles. If you find the duplication too much, delete this one and keep the new one.)
+
+- [ ] **Step 7: Run tests**
+
+```bash
+./gradlew :church-finance-backend:test --tests='*TransactionCategoryTest*' --tests='*TransactionCategoryIntegrationTest*' --rerun-tasks
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Stage and commit (Calvin runs)**
+
+```bash
+git add church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryService.kt \
+        church-finance-backend/src/main/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryController.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/service/TransactionCategoryTest.kt \
+        church-finance-backend/src/test/kotlin/com/calvintech/churchfinance/administration/api/TransactionCategoryIntegrationTest.kt
+git commit -m "feat: PATCH activate/deactivate for transaction categories
+
+Soft-deactivation via PATCH ../{id}/deactivate and ../{id}/activate
+with optimistic-lock version. Tenant-scoped 404 on both. Default
+list endpoint now excludes INACTIVE categories."
+```
+
+---
+
+## Task 12: Final full-suite sweep (ktlint + tests)
+
+**Files:** None modified — this task confirms the whole build is green and clean.
+
+- [ ] **Step 1: Run the formatter**
+
+```bash
+./gradlew :church-finance-backend:ktlintFormat
+```
+
+Expected: SUCCESS. If anything was reformatted, the diff should be minimal (whitespace / import ordering).
+
+- [ ] **Step 2: Run the full check**
+
+```bash
+./gradlew :church-finance-backend:ktlintCheck :church-finance-backend:test --rerun-tasks
+```
+
+Expected: BUILD SUCCESSFUL with all tests passing. The test count should reflect every test added across Tasks 1–11 (~30 new tests).
+
+- [ ] **Step 3: Eyeball the OpenAPI surface (optional, manual)**
+
+If you want a sanity check on the docs:
+
+```bash
+./gradlew :church-finance-backend:bootRun --args='--spring.profiles.active=local'
+```
+
+Then visit `http://localhost:8080/swagger-ui.html` and confirm:
+- All 6 transaction-category endpoints render
+- The `status` field appears on responses
+- `?status=` and `?type=` query params are documented on the list endpoint
+- 404 / 409 responses are documented where appropriate
+
+Stop the server when done (`Ctrl-C`).
+
+- [ ] **Step 4: Stage any formatter changes and commit (Calvin runs)**
+
+If `ktlintFormat` made changes:
+
+```bash
+git status                                 # confirm what changed
+git add <list of files reformatted>
+git commit -m "chore: ktlint format pass after CRUD completion"
+```
+
+If `ktlintFormat` made no changes, skip this step.
+
+- [ ] **Step 5: Ready for PR**
+
+Branch is now ready for a pull request to `main`. CodeRabbit will run on the PR (`.coderabbit.yaml` in the repo root).
+
+---
+
+## Self-review
+
+### Spec coverage
+
+Walked each section of the spec against the plan:
+
+- **Goals:**
+  - GET-by-id, list, PUT, PATCH activate/deactivate — Tasks 8, 9, 10, 11
+  - `status` field — Task 2
+  - Unique constraint swap — Task 1
+  - Church-not-found 500→404 fix — Task 6
+  - Church-aggregate-pattern parity — distributed across Tasks 2–11
+- **API surface table** — covered Task by Task
+- **Domain & persistence changes** — Tasks 2, 4, 5
+- **Service-layer logic** — Tasks 6, 7, 8, 9, 10, 11
+- **Error handling table** — Task 4
+- **Testing approach** — every test case from the spec maps to a task (persistence: Task 1 + Task 5; service unit: Tasks 6, 7, 8, 9, 10, 11; integration: Tasks 3, 6, 7, 8, 9, 10, 11)
+- **Implementation ordering** — plan order matches spec order
+
+Spec's "Open items":
+- Update existing create-201 integration test to assert on `status` — done in Task 3 ✓
+- `OpenApiConfig` changes — none needed; annotations on new controller methods only ✓
+
+### Placeholder scan
+
+No TBD/TODO in the plan. One task (Task 9) deliberately defers part of a test to Task 11 (the "deactivated category excluded from default list" assertion), with that hand-off explicitly described in both tasks. That's an intentional cross-task dependency, not a placeholder.
+
+### Type consistency
+
+Cross-task type / method names checked:
+- `TransactionCategoryStatus` (enum, ACTIVE/INACTIVE) — defined Task 2; referenced Tasks 2, 3, 9, 11
+- `TransactionCategoryStatusFilter` (enum, ACTIVE/INACTIVE/ALL with `matches`) — defined Task 9; referenced Tasks 9
+- `TransactionCategoryNotFoundException(id: UUID)` — defined Task 4; referenced Tasks 4, 8, 10, 11
+- `TransactionCategoryNameConflictException(churchId: UUID, name: String, type: FinancialTransactionType)` — defined Task 4; referenced Tasks 4, 7, 10
+- `UpdateTransactionCategoryRequest(name: String, version: Long)` — defined Task 10; referenced Task 10
+- Service signatures (`get(churchId, id)`, `list(churchId, status, type)`, `update(churchId, id, req)`, `deactivate(churchId, id, version)`, `activate(churchId, id, version)`) — consistent across tasks
+- Repository method signatures (`findByChurchIdAndNameAndTransactionType`, `findAllByChurchId`) — consistent
+
+All consistent.

--- a/docs/superpowers/plans/2026-05-25-transaction-category-crud.md
+++ b/docs/superpowers/plans/2026-05-25-transaction-category-crud.md
@@ -67,7 +67,7 @@ Open `TransactionCategoryPersistenceTest.kt` and add (alongside the existing tes
 fun `unique constraint allows same name with different transaction_type`() {
     val churchId = persistChurch()
     val income = buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.INCOME)
-    val expense = buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.EXPENSE)
+    val expense = buildJpaEntity(churchId = churchId, name = "Tithes", type = FinancialTransactionType.EXPENDITURE)
 
     transactionCategoryRepository.saveAndFlush(income)
     transactionCategoryRepository.saveAndFlush(expense)
@@ -635,7 +635,7 @@ fun `findByChurchIdAndNameAndTransactionType returns null when type differs`() {
     val found = transactionCategoryRepository.findByChurchIdAndNameAndTransactionType(
         churchId = churchId,
         name = "Offerings",
-        transactionType = FinancialTransactionType.EXPENSE,
+        transactionType = FinancialTransactionType.EXPENDITURE,
     )
 
     assertNull(found)
@@ -649,7 +649,7 @@ fun `findAllByChurchId returns only categories for that church`() {
         buildJpaEntity(churchId = churchOne, name = "A", type = FinancialTransactionType.INCOME),
     )
     transactionCategoryRepository.saveAndFlush(
-        buildJpaEntity(churchId = churchOne, name = "B", type = FinancialTransactionType.EXPENSE),
+        buildJpaEntity(churchId = churchOne, name = "B", type = FinancialTransactionType.EXPENDITURE),
     )
     transactionCategoryRepository.saveAndFlush(
         buildJpaEntity(churchId = churchTwo, name = "C", type = FinancialTransactionType.INCOME),
@@ -957,7 +957,7 @@ fun `POST should return 201 when name exists but for a different type`() {
     val churchId = UUID.fromString(createChurch())
     postCategory(churchId, "Tithes", "INCOME").andExpect(status().isCreated)
 
-    postCategory(churchId, "Tithes", "EXPENSE").andExpect(status().isCreated)
+    postCategory(churchId, "Tithes", "EXPENDITURE").andExpect(status().isCreated)
 }
 ```
 
@@ -1331,13 +1331,13 @@ fun `list returns only ACTIVE categories sorted by name when no filters supplied
 fun `list with status=ALL returns all rows sorted by name`() {
     val churchId = UUID.randomUUID()
     val a = buildTransactionCategoryJpaEntity(name = "Z", transactionType = FinancialTransactionType.INCOME)
-    val b = buildTransactionCategoryJpaEntity(name = "A", transactionType = FinancialTransactionType.EXPENSE)
+    val b = buildTransactionCategoryJpaEntity(name = "A", transactionType = FinancialTransactionType.EXPENDITURE)
         .also { it.status = TransactionCategoryStatus.INACTIVE }
 
     every { churchRepository.existsById(churchId) } returns true
     every { repository.findAllByChurchId(churchId) } returns jpaList(a, b)
     every { mapper.toDomain(a) } returns buildTransactionCategory(name = "Z", transactionType = FinancialTransactionType.INCOME)
-    every { mapper.toDomain(b) } returns buildTransactionCategory(name = "A", transactionType = FinancialTransactionType.EXPENSE)
+    every { mapper.toDomain(b) } returns buildTransactionCategory(name = "A", transactionType = FinancialTransactionType.EXPENDITURE)
         .copy(status = TransactionCategoryStatus.INACTIVE)
 
     val result = transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.ALL, type = null)
@@ -1367,12 +1367,12 @@ fun `list with status=INACTIVE returns only inactive`() {
 fun `list with type filter returns only matching type`() {
     val churchId = UUID.randomUUID()
     val income = buildTransactionCategoryJpaEntity(name = "X", transactionType = FinancialTransactionType.INCOME)
-    val expense = buildTransactionCategoryJpaEntity(name = "Y", transactionType = FinancialTransactionType.EXPENSE)
+    val expense = buildTransactionCategoryJpaEntity(name = "Y", transactionType = FinancialTransactionType.EXPENDITURE)
 
     every { churchRepository.existsById(churchId) } returns true
     every { repository.findAllByChurchId(churchId) } returns jpaList(income, expense)
     every { mapper.toDomain(income) } returns buildTransactionCategory(name = "X", transactionType = FinancialTransactionType.INCOME)
-    every { mapper.toDomain(expense) } returns buildTransactionCategory(name = "Y", transactionType = FinancialTransactionType.EXPENSE)
+    every { mapper.toDomain(expense) } returns buildTransactionCategory(name = "Y", transactionType = FinancialTransactionType.EXPENDITURE)
 
     val result = transactionCategoryService.list(churchId, TransactionCategoryStatusFilter.ACTIVE, type = FinancialTransactionType.INCOME)
 
@@ -1433,7 +1433,7 @@ fun `GET list returns 404 when church does not exist`() {
 fun `GET list with type=INCOME filters correctly`() {
     val churchId = UUID.fromString(createChurch())
     createCategoryAndReturnBody(churchId, "Tithes", "INCOME")
-    createCategoryAndReturnBody(churchId, "Bills", "EXPENSE")
+    createCategoryAndReturnBody(churchId, "Bills", "EXPENDITURE")
 
     mockMvc.perform(
         get("/api/v1/churches/{churchId}/transaction-categories", churchId)
@@ -1537,7 +1537,7 @@ Then add the endpoint method:
 @GetMapping
 @Operation(
     summary = "List transaction categories for a church",
-    description = "Returns categories for the supplied church. Defaults to ACTIVE only; use `status=ALL` or `status=INACTIVE` to broaden, and `type=INCOME` or `type=EXPENSE` to narrow.",
+    description = "Returns categories for the supplied church. Defaults to ACTIVE only; use `status=ALL` or `status=INACTIVE` to broaden, and `type=INCOME` or `type=EXPENDITURE` to narrow.",
 )
 @ApiResponses(
     value = [

--- a/docs/superpowers/specs/2026-05-25-transaction-category-crud-design.md
+++ b/docs/superpowers/specs/2026-05-25-transaction-category-crud-design.md
@@ -15,7 +15,7 @@ Categories are church-level configuration that financial transactions will later
 
 1. Provide GET-by-id, list (with filters), PUT (update name), PATCH activate, PATCH deactivate — all scoped to a church.
 2. Add a `status` field (`ACTIVE` / `INACTIVE`) to support soft-deactivation.
-3. Replace the current `(church_id, name)` unique constraint with `(church_id, name, transaction_type)` to let the same name coexist as INCOME and EXPENSE.
+3. Replace the current `(church_id, name)` unique constraint with `(church_id, name, transaction_type)` to let the same name coexist as INCOME and EXPENDITURE.
 4. Fix the existing bug where creating a category for a non-existent church returns 500 (DB FK violation) instead of 404.
 5. Match the Church aggregate's layered conventions (domain-specific exceptions, optimistic locking, service-layer business rules, `ErrorResponse(message: String)` envelope).
 
@@ -34,7 +34,7 @@ Categories are church-level configuration that financial transactions will later
 | Decision | Choice | Rationale |
 |---|---|---|
 | Delete model | Soft: status enum + activate/deactivate | Mirrors Church; categories are reference data once transactions exist; switching later would be a breaking schema change. |
-| Uniqueness scope | `(church_id, name, transaction_type)` | Lets the same name (e.g. "Tithes") exist as both INCOME and EXPENSE in one church; matches the next-steps doc's stated rule. |
+| Uniqueness scope | `(church_id, name, transaction_type)` | Lets the same name (e.g. "Tithes") exist as both INCOME and EXPENDITURE in one church; matches the next-steps doc's stated rule. |
 | Inactive rows in uniqueness | Counted (no partial index) | Simpler to reason about; reactivation can never collide because the inactive row was already occupying the slot. |
 | Update scope | Name only; type immutable | Prevents future violation of the transaction-type-must-match-category-type invariant once transactions reference categories. To change type, deactivate and create new. |
 | List default | `ACTIVE` only | The common case for a treasurer UI; `?status=ALL` or `?status=INACTIVE` available; `?type=` filter composes. |

--- a/docs/superpowers/specs/2026-05-25-transaction-category-crud-design.md
+++ b/docs/superpowers/specs/2026-05-25-transaction-category-crud-design.md
@@ -1,0 +1,314 @@
+# TransactionCategory — Read / List / Update / Deactivate / Activate
+
+- **Date:** 2026-05-25
+- **Branch:** `feature/transaction-category-crud`
+- **Status:** Approved — ready for implementation plan
+- **Aggregate:** `administration`
+
+## Context
+
+The `TransactionCategory` aggregate currently exposes only `POST /api/v1/churches/{churchId}/transaction-categories` (create). The `Church` aggregate has a full slice (GET / POST / PUT / PATCH activate / PATCH deactivate) that this work mirrors. The branch is named `feature/transaction-category-crud` and should ship a full configuration-CRUD surface before merging to `main`.
+
+Categories are church-level configuration that financial transactions will later reference. They are reference data: once a category has been used by a transaction (future work), it must not be hard-deletable. The design therefore adopts soft-deactivation from day one, even though no transactions reference categories yet — this keeps the deletion model stable across the next aggregate.
+
+## Goals
+
+1. Provide GET-by-id, list (with filters), PUT (update name), PATCH activate, PATCH deactivate — all scoped to a church.
+2. Add a `status` field (`ACTIVE` / `INACTIVE`) to support soft-deactivation.
+3. Replace the current `(church_id, name)` unique constraint with `(church_id, name, transaction_type)` to let the same name coexist as INCOME and EXPENSE.
+4. Fix the existing bug where creating a category for a non-existent church returns 500 (DB FK violation) instead of 404.
+5. Match the Church aggregate's layered conventions (domain-specific exceptions, optimistic locking, service-layer business rules, `ErrorResponse(message: String)` envelope).
+
+## Non-goals
+
+- No pagination on the list endpoint (categories per church will be dozens; YAGNI).
+- No structured error codes in the response envelope (`{ message }` shape is kept).
+- No retry-after headers on 409.
+- No multi-field validation `details` array (matches Church behaviour).
+- No changes to `OpenApiConfig` beyond annotations on the new endpoints.
+- No frontend work, no `FinancialTransactionCategorisation` work (those are separate branches per the next-steps doc).
+- No backfill of `addedBy` semantics — the current `StubCurrentUserProvider` covers `local` and `test` profiles; production auth is out of scope.
+
+## Design decisions (rationale captured)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Delete model | Soft: status enum + activate/deactivate | Mirrors Church; categories are reference data once transactions exist; switching later would be a breaking schema change. |
+| Uniqueness scope | `(church_id, name, transaction_type)` | Lets the same name (e.g. "Tithes") exist as both INCOME and EXPENSE in one church; matches the next-steps doc's stated rule. |
+| Inactive rows in uniqueness | Counted (no partial index) | Simpler to reason about; reactivation can never collide because the inactive row was already occupying the slot. |
+| Update scope | Name only; type immutable | Prevents future violation of the transaction-type-must-match-category-type invariant once transactions reference categories. To change type, deactivate and create new. |
+| List default | `ACTIVE` only | The common case for a treasurer UI; `?status=ALL` or `?status=INACTIVE` available; `?type=` filter composes. |
+| List filtering location | Service-side over `findAllByChurchId` | Categories per church are small; repo stays simple; one DB round-trip regardless of filter combo. |
+| Uniqueness conflict surfacing | Approach A: service pre-check + specific exception | Matches the project's three-layer validation principle; gives an actionable error message; DB constraint remains the safety net for TOCTOU races. |
+| Path-consistency | Category's `church_id` must match URL's `{churchId}` | Mismatch returns 404 (not 403/409) to avoid leaking the existence of categories across tenants. |
+| Migration default for `status` | `DEFAULT 'ACTIVE'`, kept | JPA always supplies the value on insert, so the DB default is invisible to the app — it exists purely so the `ALTER TABLE ADD COLUMN` succeeds. |
+
+## API surface
+
+All endpoints under `/api/v1/churches/{churchId}/transaction-categories`.
+
+| Method | Path | Success | Errors |
+|---|---|---|---|
+| POST | `/` | 201 + `TransactionCategoryResponse` | 400 validation, 404 church not found, 409 name conflict |
+| GET | `/{id}` | 200 + `TransactionCategoryResponse` | 404 not found / tenant mismatch |
+| GET | `/` | 200 + `List<TransactionCategoryResponse>` (sorted by name asc) | 404 church not found |
+| PUT | `/{id}` | 200 + `TransactionCategoryResponse` | 400, 404, 409 (name conflict or stale version) |
+| PATCH | `/{id}/deactivate?version=N` | 200 + `TransactionCategoryResponse` | 404, 409 stale version |
+| PATCH | `/{id}/activate?version=N` | 200 + `TransactionCategoryResponse` | 404, 409 stale version |
+
+### Request DTOs (api/)
+
+**`CreateTransactionCategoryRequest`** (already exists, unchanged):
+```kotlin
+data class CreateTransactionCategoryRequest(
+    @field:NotBlank val name: String,
+    val type: FinancialTransactionType,
+)
+```
+
+**`UpdateTransactionCategoryRequest`** (new):
+```kotlin
+data class UpdateTransactionCategoryRequest(
+    @field:NotBlank val name: String,
+    val version: Long,
+)
+```
+
+**`TransactionCategoryStatusFilter`** (new — query-param-only enum, lives in `api/`):
+```kotlin
+enum class TransactionCategoryStatusFilter { ACTIVE, INACTIVE, ALL }
+```
+Spring binds it from `?status=` via enum binding. Default value on the controller method is `ACTIVE`.
+
+### Response DTO
+
+**`TransactionCategoryResponse`** gains `status`:
+```kotlin
+data class TransactionCategoryResponse(
+    val id: UUID,
+    val name: String,
+    val type: FinancialTransactionType,
+    val status: TransactionCategoryStatus,
+    val version: Long,
+)
+```
+The existing create-201 integration test will need updating to assert on the new `status` field.
+
+## Domain & persistence changes
+
+### New domain types (administration/domain/)
+
+```kotlin
+enum class TransactionCategoryStatus { ACTIVE, INACTIVE }
+```
+
+```kotlin
+class TransactionCategoryNotFoundException(id: UUID)
+    : RuntimeException("Transaction category not found: $id")
+```
+
+```kotlin
+class TransactionCategoryNameConflictException(
+    churchId: UUID,
+    name: String,
+    type: FinancialTransactionType,
+) : RuntimeException(
+    "A category named '$name' already exists for $type in this church."
+)
+```
+
+### TransactionCategory domain class — adds `status`
+
+```kotlin
+data class TransactionCategory(
+    val id: Ulid,
+    val churchId: Ulid,
+    val createdAt: Instant,
+    val addedBy: Ulid,
+    val name: String,
+    val transactionType: FinancialTransactionType,
+    val status: TransactionCategoryStatus = TransactionCategoryStatus.ACTIVE,
+    val version: Long = 0,
+) {
+    init { require(name.isNotBlank()) { "Name must not be blank" } }
+}
+```
+
+### JPA entity (TransactionCategoryJpaEntity) — adds `status`
+
+```kotlin
+@Enumerated(EnumType.STRING)
+var status: TransactionCategoryStatus = TransactionCategoryStatus.ACTIVE
+```
+Mapper round-trips the field in both directions.
+
+### Repository additions
+
+```kotlin
+interface TransactionCategoryRepository : JpaRepository<TransactionCategoryJpaEntity, UUID> {
+    fun findByChurchIdAndNameAndTransactionType(
+        churchId: UUID,
+        name: String,
+        transactionType: FinancialTransactionType,
+    ): TransactionCategoryJpaEntity?
+
+    fun findAllByChurchId(churchId: UUID): List<TransactionCategoryJpaEntity>
+}
+```
+
+### Flyway migration `V3__transaction_category_status_and_unique.sql`
+
+```sql
+ALTER TABLE church_finance.transaction_category
+    ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE';
+
+ALTER TABLE church_finance.transaction_category
+    DROP CONSTRAINT transaction_category_church_name_unique;
+
+ALTER TABLE church_finance.transaction_category
+    ADD CONSTRAINT transaction_category_church_name_type_unique
+        UNIQUE (church_id, name, transaction_type);
+```
+
+## Service-layer logic
+
+`TransactionCategoryService` gains a `ChurchRepository` dependency and grows the following methods (signature-level — see brainstorming pseudocode for the full shape).
+
+### Public methods
+
+```kotlin
+fun create(churchId: UUID, req: CreateTransactionCategoryRequest): TransactionCategoryResponse
+fun get(churchId: UUID, id: UUID): TransactionCategoryResponse
+fun list(
+    churchId: UUID,
+    status: TransactionCategoryStatusFilter,   // default ACTIVE — defaulted at controller layer
+    type: FinancialTransactionType?,           // null = no type filter
+): List<TransactionCategoryResponse>
+fun update(churchId: UUID, id: UUID, req: UpdateTransactionCategoryRequest): TransactionCategoryResponse
+fun deactivate(churchId: UUID, id: UUID, version: Long): TransactionCategoryResponse
+fun activate(churchId: UUID, id: UUID, version: Long): TransactionCategoryResponse
+```
+
+### Private helpers
+
+- **`requireChurchExists(churchId: UUID)`** — `churchRepository.existsById(churchId)` else throws `ChurchNotFoundException(churchId)` → 404. Called by `create` and `list`. (For `get`/`update`/`deactivate`/`activate` it's redundant: `findCategoryScopedToChurch` already loads a category and verifies its `churchId`.)
+- **`requireNameAvailable(churchId, name, type, excludingId: UUID?)`** — queries `findByChurchIdAndNameAndTransactionType`; if found and `existing.id != excludingId`, throws `TransactionCategoryNameConflictException(churchId, name, type)` → 409.
+- **`findCategoryScopedToChurch(churchId, id): TransactionCategory`** — loads by id; if missing OR its `church_id != churchId`, throws `TransactionCategoryNotFoundException(id)` → 404.
+- **`saveAndRespond(category): TransactionCategoryResponse`** — existing pattern; persists and rebuilds the DTO from the round-tripped domain entity.
+
+### Validation ordering
+
+- **create**: `requireChurchExists` → `requireNameAvailable(excludingId = null)` → build + save.
+- **update**: `findCategoryScopedToChurch` → if `existing.name != req.name` then `requireNameAvailable(existing.transactionType, excludingId = id)` → `copy(name, version)` → save.
+- **activate / deactivate**: `findCategoryScopedToChurch` → `copy(status, version)` → save. No uniqueness check needed because inactive rows still count toward uniqueness.
+- **list**: `requireChurchExists` → load all → filter by status and type → sort by name → map.
+
+## Error handling
+
+Additions to `GlobalExceptionHandler`:
+
+| New handler | HTTP | Message |
+|---|---|---|
+| `TransactionCategoryNotFoundException` | 404 | `ex.message` (`"Transaction category not found: <id>"`) |
+| `TransactionCategoryNameConflictException` | 409 | `ex.message` (`"A category named '<name>' already exists for <type> in this church."`) |
+| `DataIntegrityViolationException` (TOCTOU safety net) | 409 | `"Conflict — please refresh and try again."` |
+
+Reused (existing) handlers:
+- `ChurchNotFoundException` → 404
+- `MethodArgumentNotValidException` → 400
+- `ObjectOptimisticLockingFailureException` → 409 (`"Someone else has made a change. Please refresh and try again."`)
+
+Response envelope is the existing `ErrorResponse(message: String)`.
+
+## Testing approach
+
+Three layers; ~30 new test methods total.
+
+### Service unit tests (`administration/service/TransactionCategoryTest.kt`)
+
+Existing file's create happy-path stays. Add a `ChurchRepository` mock to the setup.
+
+- `create` — existing happy path
+- `create throws ChurchNotFoundException when church does not exist`
+- `create throws TransactionCategoryNameConflictException when (church, name, type) already exists`
+- `get returns category when it belongs to the church`
+- `get throws TransactionCategoryNotFoundException when id unknown`
+- `get throws TransactionCategoryNotFoundException when category belongs to a different church` (tenant-leak guard)
+- `list returns only ACTIVE categories sorted by name when no filters supplied`
+- `list with status=ALL returns all rows`
+- `list with status=INACTIVE returns only inactive`
+- `list with type filter returns only matching type`
+- `list with both filters composes correctly`
+- `list throws ChurchNotFoundException when church does not exist`
+- `update changes name, preserves type and status, returns updated response`
+- `update skips uniqueness check when name is unchanged` (verified via MockK `verify(exactly = 0)`)
+- `update throws conflict when new name collides with another category of the same type`
+- `update permits keeping the same name as the category's own current value` (excludingId guard)
+- `update throws not-found on tenant mismatch`
+- `deactivate sets status to INACTIVE`
+- `activate sets status to ACTIVE`
+- `deactivate throws not-found on tenant mismatch`
+- `activate throws not-found on tenant mismatch`
+
+### Persistence integration tests (`administration/persistence/TransactionCategoryPersistenceTest.kt`)
+
+Existing round-trip test stays. Add:
+
+- `status field round-trips through JPA` (ACTIVE → save → fetch → flip to INACTIVE → save → fetch)
+- `unique constraint rejects duplicate (church_id, name, transaction_type)` — assert `DataIntegrityViolationException`
+- `unique constraint allows same name with different transaction_type` (regression-guard for the migration's intent)
+- `unique constraint allows same name in different churches` (tenancy boundary sanity)
+
+### Controller integration tests (`administration/api/TransactionCategoryIntegrationTest.kt`)
+
+Existing create-201 test stays but is **updated to assert on the new `status` field** (it doesn't today). Add helpers `createCategory`, `extractId`, `extractVersion` (mirroring the Church integration test helpers).
+
+- `POST returns 409 when name already exists for the same type in the same church`
+- `POST returns 201 when name exists but for a different type` (positive uniqueness case)
+- `POST returns 404 when church does not exist`
+- `GET by id returns the category`
+- `GET by id returns 404 when category does not exist`
+- `GET by id returns 404 when category belongs to a different church`
+- `GET list returns only ACTIVE categories by default`
+- `GET list with status=ALL includes inactive`
+- `GET list with type=INCOME filters correctly`
+- `GET list returns empty list when church has no categories` (not 404 — empty collection is the right answer)
+- `GET list returns 404 when church does not exist`
+- `GET list sorts by name ascending`
+- `PUT updates name and returns 200`
+- `PUT returns 400 on blank name`
+- `PUT returns 404 on unknown id`
+- `PUT returns 404 on tenant mismatch`
+- `PUT returns 409 when stale version`
+- `PUT returns 409 when new name collides with another category of the same type`
+- `PATCH deactivate sets status to INACTIVE`
+- `PATCH activate sets status to ACTIVE`
+- `PATCH deactivate returns 404 on unknown id or tenant mismatch`
+- `PATCH activate returns 404 on unknown id or tenant mismatch`
+- `Deactivated category is excluded from default list but included with status=ALL`
+
+### Out of test scope
+
+- OpenAPI / Swagger doc rendering. SpringDoc internals.
+- Performance / load testing of list endpoint. Reference-table scale assumed.
+
+## Implementation ordering (informative — `writing-plans` will sequence)
+
+The natural TDD order:
+
+1. Flyway `V3` migration + persistence test for the new unique constraint → green.
+2. Domain changes (`TransactionCategoryStatus` enum, `status` field on `TransactionCategory`, two new exceptions) + JPA entity + mapper changes + persistence test for `status` round-trip → green.
+3. `TransactionCategoryResponse` gains `status` field; update existing create-201 integration test assertion.
+4. Service-level: add `ChurchRepository` dependency, the three helpers, and each new method one at a time with its service unit tests → green.
+5. `GlobalExceptionHandler` additions (three new handlers).
+6. Controller: add `UpdateTransactionCategoryRequest`, `TransactionCategoryStatusFilter`, and the four new endpoints (GET-by-id, list, PUT, PATCH activate, PATCH deactivate) with OpenAPI annotations matching the Church controller's style.
+7. Integration tests for each new endpoint → green.
+8. `./gradlew ktlintFormat ktlintCheck test` → all green.
+9. Sanity-check the OpenAPI surface in the browser; eyeball-only.
+
+## Open items
+
+None blocking. Items the implementation plan must confirm:
+
+- Today's `TransactionCategoryIntegrationTest.kt` does not assert on `status` (it doesn't exist yet) — update the existing assertion in the same change that adds the field.
+- `OpenApiConfig` may not need changes; annotations on the new controller methods should suffice. Confirm during implementation.


### PR DESCRIPTION
## Summary
- Adds GET-by-id, list (filterable), PUT (name only), and PATCH activate/deactivate for `TransactionCategory` — mirroring the Church aggregate's slice.
- Soft-deactivation via `status` enum (ACTIVE/INACTIVE); Flyway V3 swaps the unique constraint to `(church_id, name, transaction_type)` so the same name can coexist as INCOME and EXPENDITURE; tenant-scoped 404 prevents cross-tenant ID enumeration.
- Fixes existing bug where creating a category against a non-existent church returned 500 (DB FK violation) instead of 404.

Built via a spec-driven workflow (brainstorm → plan → 12 task-by-task TDD passes with per-task reviews). See the committed spec and plan:
- `docs/superpowers/specs/2026-05-25-transaction-category-crud-design.md`
- `docs/superpowers/plans/2026-05-25-transaction-category-crud.md`

## Test plan
- [ ] CI green (`./gradlew ktlintCheck test` — 124 tests locally)
- [ ] Swagger UI (`/swagger-ui.html`) renders the six endpoints with correct request/response schemas
- [ ] Manual: POST same name with different types (INCOME vs EXPENDITURE) — both succeed
- [ ] Manual: POST against an unknown church UUID → 404 (not 500)
- [ ] Manual: PATCH `/{id}/deactivate` then GET list → deactivated category absent by default; `?status=ALL` includes it

## Notes for reviewers

**Pre-existing scope-creep commit.** Commit \`0a1f4e4\` ("Added OpenAPI spec and API integration guide") pre-dates the CRUD work in this branch and includes unrelated infrastructure changes: \`Dockerfile\`, \`docker-compose.yml\`, \`OpenApiConfig.kt\`, broadening \`StubCurrentUserProvider\`'s \`@Profile\` to \`"docker"\`, and a default DB-name change from \`church_finance\` → \`app\` in \`application.yaml\`. The DB-name change is at odds with \`CLAUDE.md\` which still references \`church_finance\`. Happy to split this commit into its own PR if preferred — flag in review.

**\`DataIntegrityViolationException → 409\` HTTP coverage gap.** The new global handler for the unique-constraint TOCTOU safety net is wired but doesn't have an HTTP-layer integration test. Testing deterministically would require \`@MockkBean\`/\`@SpykBean\` from \`com.ninja-squad:springmockk\` which isn't a current dependency. The persistence test covers the underlying DB-level rejection; the handler-wiring is trivial. Adding the dependency just to test this one handler isn't worth it — open to opinions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added transaction category management with create, retrieve, update, and status control capabilities.
  * Categories can be filtered by status and transaction type with automatic sorting.

* **Documentation**
  * Enhanced API documentation with comprehensive Swagger/OpenAPI specifications.

* **Infrastructure**
  * Added Docker containerisation for simplified deployment and local development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/calvinthomas150/church-finance/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->